### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ send us pull requests. You can also report bugs or file feature requests.
 
 If you'd like to talk to the developers or get notified about major product
 updates, you may want to subscribe to our
-[mailing list](sandboxed-api-users@googlegroups.com).
+[mailing list](mailto:sandboxed-api-users@googlegroups.com) or sign up with this [link](https://groups.google.com/forum/#!forum/sandboxed-api-users).


### PR DESCRIPTION
Due to how github handles urls, before this PR the `mailing list` linked to https://github.com/google/sandboxed-api/blob/master/sandboxed-api-users@googlegroups.com

I allso added a link to sign up to the google group/mailing list.