### PR TITLE
CMake support for Sandbox2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,101 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.5)
+
+option(USE_SUPERBUILD "Whether or not a superbuild should be invoked" ON)
+if(USE_SUPERBUILD)
+  project(superbuild NONE)
+  include(cmake/SuperBuild.cmake)
+  return()
+endif()
+project(sandboxed_api C CXX ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_PREFIX_PATH
+  "${PROJECT_BINARY_DIR}/Dependencies/Build/gflags"
+  "${PROJECT_BINARY_DIR}/Dependencies/Build/glog"
+)
+
+include(SapiCompilerOptions)
+include(SapiUtil)
+include(GoogleTest)
+
+# Build Abseil directly, as recommended upstream
+find_path(absl_src_dir
+  absl/base/port.h
+  HINTS ${ABSL_ROOT_DIR}
+  PATHS ${PROJECT_BINARY_DIR}/Dependencies/Source/absl
+)
+add_subdirectory(${absl_src_dir}
+                 ${PROJECT_BINARY_DIR}/Dependencies/Build/absl
+                 EXCLUDE_FROM_ALL)
+
+# Build Googletest directly, as recommended upstream
+find_path(googletest_src_dir
+  googletest/include/gtest/gtest.h
+  HINTS ${GOOGLETEST_ROOT_DIR}
+  PATHS ${PROJECT_BINARY_DIR}/Dependencies/Source/googletest
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+add_subdirectory(${googletest_src_dir}
+                 ${PROJECT_BINARY_DIR}/Dependencies/Build/googletest
+                 EXCLUDE_FROM_ALL)
+
+# Always use static libraries
+if(WIN32)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+else()
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()
+
+find_package(gflags REQUIRED)
+find_package(glog REQUIRED)
+find_package(Protobuf REQUIRED)
+find_package(Libcap REQUIRED)
+
+# Make Bazel-like includes work
+configure_file(cmake/libcap_capability.h.in
+               external/org_kernel_libcap/libcap/include/sys/capability.h
+               @ONLY)
+set(libunwind_INCLUDE_DIR
+  ${PROJECT_BINARY_DIR}/Dependencies/Source/libunwind/include)
+configure_file(cmake/libunwind_ptrace.h.in
+               external/org_gnu_libunwind/include/libunwind-ptrace.h
+               @ONLY)
+
+# Interface library with basic project settings
+add_library(sapi_base INTERFACE)
+add_library(sapi::base ALIAS sapi_base)
+target_include_directories(sapi_base INTERFACE
+  ${PROJECT_BINARY_DIR}
+  ${PROJECT_SOURCE_DIR}
+  # Need to reach into Abseil internal headers from a few targets.
+  ${PROJECT_BINARY_DIR}/Dependencies/Source/absl
+)
+
+add_library(sapi_test_main INTERFACE)
+add_library(sapi::test_main ALIAS sapi_test_main)
+target_link_libraries(sapi_test_main INTERFACE
+  gtest_main
+  gmock
+  sapi::base
+)
+
+# Setup tests to work like with Bazel
+create_directory_symlink(${PROJECT_SOURCE_DIR} com_google_sandboxed_api)
+enable_testing()
+
+add_subdirectory(cmake/libunwind)
+add_subdirectory(sandboxed_api)

--- a/cmake/FindLibcap.cmake
+++ b/cmake/FindLibcap.cmake
@@ -1,0 +1,34 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# On Debian, install libcap-dev to use this module.
+
+find_path(libcap_INCLUDE_DIR sys/capability.h)
+# Look for static library only.
+find_library(libcap_LIBRARY libcap.a)
+mark_as_advanced(libcap_INCLUDE_DIR libcap_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(libcap
+  REQUIRED_VARS libcap_LIBRARY libcap_INCLUDE_DIR
+)
+
+if(libcap_FOUND AND NOT TARGET libcap::libcap)
+  add_library(libcap::libcap UNKNOWN IMPORTED)
+  set_target_properties(libcap::libcap PROPERTIES
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+    IMPORTED_LOCATION "${libcap_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${libcap_INCLUDE_DIR}"
+  )
+endif()

--- a/cmake/FindLibunwind.cmake
+++ b/cmake/FindLibunwind.cmake
@@ -1,0 +1,34 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# On Debian, install libunwind-dev to use this module.
+
+find_path(libunwind_INCLUDE_DIR sys/capability.h)
+# Look for static library only.
+find_library(libunwind_LIBRARY libcap.a)
+mark_as_advanced(libunwind_INCLUDE_DIR libcap_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(libunwind
+  REQUIRED_VARS libunwind_LIBRARY libcap_INCLUDE_DIR
+)
+
+if(libunwind_FOUND AND NOT TARGET libcap::libcap)
+  add_library(libunwind::libcap UNKNOWN IMPORTED)
+  set_target_properties(libunwind::libcap PROPERTIES
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+    IMPORTED_LOCATION "${libunwind_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${libunwind_INCLUDE_DIR}"
+  )
+endif()

--- a/cmake/SapiCompilerOptions.cmake
+++ b/cmake/SapiCompilerOptions.cmake
@@ -1,0 +1,34 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_SKIP_BUILD_RPATH TRUE)
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+
+# Compiler-specific global options
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")  # GCC
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+else()
+  message(FATAL_ERROR "Unsupported compiler")
+endif()
+
+# OS-specific global options
+if(UNIX)
+  add_compile_options(-Wno-deprecated)
+else()
+  message(FATAL_ERROR "Unsupported OS")
+endif()

--- a/cmake/SapiUtil.cmake
+++ b/cmake/SapiUtil.cmake
@@ -1,0 +1,89 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Creates an alias for SOURCE, called DESTINATION.
+#
+# On platforms that support them, this rule will effectively create a symlink.
+#
+# SOURCE may be relative to CMAKE_CURRENT_SOURCE_DIR, or absolute.
+# DESTINATION may relative to CMAKE_CURRENT_BINARY_DIR, or absolute.
+#
+# Adapted from https://github.com/google/binexport/blob/master/util.cmake
+function(create_directory_symlink SOURCE DESTINATION)
+  get_filename_component(_destination_parent "${DESTINATION}" DIRECTORY)
+  file(MAKE_DIRECTORY "${_destination_parent}")
+
+  if (WIN32)
+    file(TO_NATIVE_PATH "${SOURCE}" _native_source)
+    file(TO_NATIVE_PATH "${DESTINATION}" _native_destination)
+    execute_process(COMMAND $ENV{ComSpec} /c
+        mklink /J "${_native_destination}" "${_native_source}" ERROR_QUIET)
+  else()
+    execute_process(COMMAND ${CMAKE_COMMAND} -E
+      create_symlink "${SOURCE}" "${DESTINATION}")
+  endif()
+endfunction()
+
+# Helper function that behaves just like protobuf_generate_cpp(), except that
+# it strips import paths. This is necessary, because CMake's protobuf rules
+# don't work well with imports across different directories.
+function(sapi_protobuf_generate_cpp SRCS HDRS PROTO)
+  file(READ ${PROTO} _pb_orig)
+  string(REGEX REPLACE "import \".*/([^/]+\\.proto)\""
+                       "import \"\\1\"" _pb_repl "${_pb_orig}")
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROTO} "${_pb_repl}")
+  protobuf_generate_cpp(_srcs _hdrs ${CMAKE_CURRENT_BINARY_DIR}/${PROTO})
+  set(${SRCS} ${_srcs} PARENT_SCOPE)
+  set(${HDRS} ${_hdrs} PARENT_SCOPE)
+endfunction()
+
+# Embeds arbitrary binary data into a static library.
+#
+# NAME specifies the name for this target.
+# NAMESPACE is the C++ namespace the generated code is placed in. Can be empty.
+# SOURCES is a list of files that should be embedded. If a source names a
+#   target the target binary is embedded instead.
+macro(sapi_cc_embed_data)
+  cmake_parse_arguments(_sapi_embed "" "NAME;NAMESPACE" "SOURCES" ${ARGN})
+  foreach(src ${_sapi_embed_SOURCES})
+    if(TARGET ${src})
+      list(APPEND _sapi_embed_in ${CMAKE_CURRENT_BINARY_DIR}/${src})
+    else()
+      list(APPEND _sapi_embed_in ${src})
+    endif()
+  endforeach()
+  file(RELATIVE_PATH _sapi_embed_pkg
+                     ${PROJECT_BINARY_DIR}
+                     ${CMAKE_CURRENT_BINARY_DIR})
+  add_custom_command(
+    OUTPUT ${_sapi_embed_NAME}.h ${_sapi_embed_NAME}.cc
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND filewrapper ${_sapi_embed_pkg}
+                        ${_sapi_embed_NAME}
+                        "${_sapi_embed_NAMESPACE}"
+                        ${CMAKE_CURRENT_BINARY_DIR}/${_sapi_embed_NAME}.h
+                        ${CMAKE_CURRENT_BINARY_DIR}/${_sapi_embed_NAME}.cc
+                        ${_sapi_embed_in}
+    DEPENDS ${_sapi_embed_SOURCES}
+    VERBATIM
+  )
+  add_library(${_sapi_embed_NAME} STATIC
+    ${_sapi_embed_NAME}.h
+    ${_sapi_embed_NAME}.cc
+  )
+  target_link_libraries(${_sapi_embed_NAME} PRIVATE
+    sapi::base
+    absl::core_headers
+  )
+endmacro()

--- a/cmake/SuperBuild.cmake
+++ b/cmake/SuperBuild.cmake
@@ -1,0 +1,70 @@
+include(ExternalProject)
+
+set_property(DIRECTORY PROPERTY EP_BASE Dependencies)
+
+set(DEPENDENCIES)
+set(EXTRA_CMAKE_ARGS)
+
+ExternalProject_Add(absl
+  GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
+  GIT_TAG 88a152ae747c3c42dc9167d46c590929b048d436
+  # Just clone into directory
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+)
+list(APPEND DEPENDENCIES absl)
+
+ExternalProject_Add(gflags
+  GIT_REPOSITORY https://github.com/gflags/gflags.git
+  GIT_TAG 28f50e0fed19872e0fd50dd23ce2ee8cd759338e
+  CMAKE_ARGS -DGFLAGS_IS_SUBPROJECT=TRUE
+  INSTALL_COMMAND ""
+)
+list(APPEND DEPENDENCIES gflags)
+
+ExternalProject_Add(glog
+  DEPENDS gflags
+  GIT_REPOSITORY https://github.com/google/glog.git
+  GIT_TAG 41f4bf9cbc3e8995d628b459f6a239df43c2b84a
+  CMAKE_ARGS
+    # Disable symbolizer
+    -DCMAKE_PREFIX_PATH= -DUNWIND_LIBRARY=
+    # getpwuid_r() cannot be linked statically with glibc
+    -DHAVE_PWD_H=
+  INSTALL_COMMAND ""
+)
+list(APPEND DEPENDENCIES glog)
+
+ExternalProject_Add(googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG f80d6644d4b451f568a2e7aea1e01e842eb242dc  # 2019-02-05
+  # Just clone into directory
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+)
+list(APPEND DEPENDENCIES googletest)
+
+ExternalProject_Add(libunwind
+  URL https://github.com/libunwind/libunwind/releases/download/v1.2.1/libunwind-1.2.1.tar.gz
+  URL_HASH SHA256=3f3ecb90e28cbe53fba7a4a27ccce7aad188d3210bb1964a923a731a27a75acb
+  # Need to invoke a custom build, so just download and extract
+  CONFIGURE_COMMAND ./configure
+                    --disable-documentation
+                    --disable-minidebuginfo
+                    --disable-shared
+                    --enable-ptrace
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  BUILD_IN_SOURCE TRUE
+)
+list(APPEND DEPENDENCIES libunwind)
+
+ExternalProject_Add(sandboxed_api
+  DEPENDS ${DEPENDENCIES}
+  SOURCE_DIR ${PROJECT_SOURCE_DIR}
+  CMAKE_ARGS -DUSE_SUPERBUILD=OFF ${EXTRA_CMAKE_ARGS}
+  INSTALL_COMMAND ""
+  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}
+)

--- a/cmake/libcap_capability.h.in
+++ b/cmake/libcap_capability.h.in
@@ -1,0 +1,21 @@
+// Copyright 2019 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SANDBOXED_API_CMAKE_LIBCAP_CAPABILITY_H_
+#define SANDBOXED_API_CMAKE_LIBCAP_CAPABILITY_H_
+
+// Forward include to location found by find_package()
+#include "@libcap_INCLUDE_DIR@/sys/capability.h"
+
+#endif  // SANDBOXED_API_CMAKE_LIBCAP_CAPABILITY_H_

--- a/cmake/libunwind/CMakeLists.txt
+++ b/cmake/libunwind/CMakeLists.txt
@@ -1,0 +1,135 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Custom build for libunwind. We need this to remap libunwind symbols.
+
+set(_unwind_src ${PROJECT_BINARY_DIR}/Dependencies/Source/libunwind)
+
+foreach(wrapped _wrapped "")
+  add_library(unwind_ptrace${wrapped} STATIC
+    # internal_headers
+    ${_unwind_src}/include/compiler.h
+    ${_unwind_src}/include/config.h
+    ${_unwind_src}/include/dwarf.h
+    ${_unwind_src}/include/dwarf-eh.h
+    ${_unwind_src}/include/dwarf_i.h
+    ${_unwind_src}/include/libunwind.h
+    ${_unwind_src}/include/libunwind-common.h
+    ${_unwind_src}/include/libunwind-coredump.h
+    ${_unwind_src}/include/libunwind-dynamic.h
+    ${_unwind_src}/include/libunwind-ptrace.h
+    ${_unwind_src}/include/libunwind-x86_64.h
+    ${_unwind_src}/include/libunwind_i.h
+    ${_unwind_src}/include/mempool.h
+    ${_unwind_src}/include/remote.h
+    ${_unwind_src}/include/tdep-x86_64/dwarf-config.h
+    ${_unwind_src}/include/tdep-x86_64/libunwind_i.h
+    ${_unwind_src}/include/tdep/dwarf-config.h
+    ${_unwind_src}/include/tdep/libunwind_i.h
+    ${_unwind_src}/include/unwind.h
+    ${_unwind_src}/src/elf32.h
+    ${_unwind_src}/src/elf64.h
+    ${_unwind_src}/src/elfxx.h
+    ${_unwind_src}/src/os-linux.h
+    ${_unwind_src}/src/x86_64/init.h
+    ${_unwind_src}/src/x86_64/offsets.h
+    ${_unwind_src}/src/x86_64/ucontext_i.h
+    ${_unwind_src}/src/x86_64/unwind_i.h
+    # included_sources
+    ${_unwind_src}/src/elf64.h
+    ${_unwind_src}/src/elfxx.h
+    ${_unwind_src}/src/elfxx.c
+    # sources_common
+    ${_unwind_src}/src/dwarf/Gexpr.c
+    ${_unwind_src}/src/dwarf/Gfde.c
+    ${_unwind_src}/src/dwarf/Gfind_proc_info-lsb.c
+    ${_unwind_src}/src/dwarf/Gfind_unwind_table.c
+    ${_unwind_src}/src/dwarf/Gparser.c
+    ${_unwind_src}/src/dwarf/Gpe.c
+    ${_unwind_src}/src/dwarf/Gstep.c
+    ${_unwind_src}/src/dwarf/global.c
+    ${_unwind_src}/src/mi/Gdestroy_addr_space.c
+    ${_unwind_src}/src/mi/Gdyn-extract.c
+    ${_unwind_src}/src/mi/Gfind_dynamic_proc_info.c
+    ${_unwind_src}/src/mi/Gget_accessors.c
+    ${_unwind_src}/src/mi/Gget_proc_name.c
+    ${_unwind_src}/src/mi/Gget_reg.c
+    ${_unwind_src}/src/mi/Gput_dynamic_unwind_info.c
+    ${_unwind_src}/src/mi/flush_cache.c
+    ${_unwind_src}/src/mi/init.c
+    ${_unwind_src}/src/mi/mempool.c
+    ${_unwind_src}/src/os-linux.c
+    ${_unwind_src}/src/x86_64/Gcreate_addr_space.c
+    ${_unwind_src}/src/x86_64/Gglobal.c
+    ${_unwind_src}/src/x86_64/Ginit.c
+    ${_unwind_src}/src/x86_64/Gos-linux.c
+    ${_unwind_src}/src/x86_64/Gregs.c
+    ${_unwind_src}/src/x86_64/Gresume.c
+    ${_unwind_src}/src/x86_64/Gstash_frame.c
+    ${_unwind_src}/src/x86_64/Gstep.c
+    ${_unwind_src}/src/x86_64/is_fpreg.c
+    ${_unwind_src}/src/x86_64/setcontext.S
+    # srcs
+    ${_unwind_src}/src/mi/Gdyn-remote.c
+    ${_unwind_src}/src/ptrace/_UPT_access_fpreg.c
+    ${_unwind_src}/src/ptrace/_UPT_access_mem.c
+    ${_unwind_src}/src/ptrace/_UPT_access_reg.c
+    ${_unwind_src}/src/ptrace/_UPT_accessors.c
+    ${_unwind_src}/src/ptrace/_UPT_create.c
+    ${_unwind_src}/src/ptrace/_UPT_destroy.c
+    ${_unwind_src}/src/ptrace/_UPT_elf.c
+    ${_unwind_src}/src/ptrace/_UPT_find_proc_info.c
+    ${_unwind_src}/src/ptrace/_UPT_get_dyn_info_list_addr.c
+    ${_unwind_src}/src/ptrace/_UPT_get_proc_name.c
+    ${_unwind_src}/src/ptrace/_UPT_internal.h
+    ${_unwind_src}/src/ptrace/_UPT_put_unwind_info.c
+    ${_unwind_src}/src/ptrace/_UPT_reg_offset.c
+    ${_unwind_src}/src/ptrace/_UPT_resume.c
+    # hdrs
+    ${_unwind_src}/include/config.h
+    ${_unwind_src}/include/libunwind.h
+    # source_ptrace
+    ${_unwind_src}/src/x86_64/Ginit_remote.c
+  )
+  add_library(unwind::unwind_ptrace${wrapped} ALIAS unwind_ptrace${wrapped})
+  target_include_directories(unwind_ptrace${wrapped} PRIVATE
+    ${_unwind_src}/include
+    ${_unwind_src}/include/tdep
+    ${_unwind_src}/src
+  )
+  target_compile_options(unwind_ptrace${wrapped} PRIVATE
+    -fno-common
+    -Wno-cpp
+  )
+  target_compile_definitions(unwind_ptrace${wrapped} PRIVATE
+    -DHAVE_CONFIG_H
+    -D_GNU_SOURCE
+    -DNO_FRAME_POINTER
+  )
+  target_link_libraries(unwind_ptrace${wrapped} PRIVATE
+    sapi::base
+  )
+endforeach()
+target_compile_definitions(unwind_ptrace_wrapped PUBLIC
+  -D_UPT_accessors=_UPT_accessors_wrapped
+  -D_UPT_create=_UPT_create_wrapped
+  -D_UPT_destroy=_UPT_destroy_wrapped
+  -D_Ux86_64_create_addr_space=_Ux86_64_create_addr_space_wrapped
+  -D_Ux86_64_destroy_addr_space=_Ux86_64_destroy_addr_space_wrapped
+  -D_Ux86_64_get_proc_name=_Ux86_64_get_proc_name_wrapped
+  -D_Ux86_64_get_reg=_Ux86_64_get_reg_wrapped
+  -D_Ux86_64_init_remote=_Ux86_64_init_remote_wrapped
+  -D_Ux86_64_step=_Ux86_64_step_wrapped
+  -Dptrace=ptrace_wrapped
+)

--- a/cmake/libunwind_ptrace.h.in
+++ b/cmake/libunwind_ptrace.h.in
@@ -1,0 +1,21 @@
+// Copyright 2019 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SANDBOXED_API_CMAKE_LIBUNWIND_PTRACE_H_
+#define SANDBOXED_API_CMAKE_LIBUNWIND_PTRACE_H_
+
+// Forward include to location set up by SuperBuild
+#include "@libunwind_INCLUDE_DIR@/libunwind-ptrace.h"
+
+#endif  // SANDBOXED_API_CMAKE_LIBUNWIND_PTRACE_H_

--- a/sandboxed_api/CMakeLists.txt
+++ b/sandboxed_api/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(bazel)  # For filewrapper
+add_subdirectory(sandbox2)
+add_subdirectory(util)
+
+# sandboxed_api:embed_file
+add_library(sapi_embed_file STATIC
+  embed_file.cc
+  embed_file.h
+  file_toc.h
+)
+add_library(sapi::embed_file ALIAS sapi_embed_file)
+target_link_libraries(sapi_embed_file PRIVATE
+  absl::flat_hash_map
+  absl::strings
+  absl::synchronization
+  glog::glog
+  sandbox2::fileops
+  sandbox2::strerror
+  sandbox2::util
+  sapi::base
+  sapi::raw_logging
+  sapi::status
+)

--- a/sandboxed_api/bazel/CMakeLists.txt
+++ b/sandboxed_api/bazel/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# sandboxed_api/bazel:filewrapper
+add_executable(filewrapper
+  filewrapper.cc
+)
+target_link_libraries(filewrapper PRIVATE
+  absl::strings
+  sandbox2::fileops
+  sandbox2::strerror
+  sapi::base
+  sapi::raw_logging
+)
+
+sapi_cc_embed_data(NAME filewrapper_embedded
+  NAMESPACE ""
+  SOURCES testdata/filewrapper_embedded.bin
+)
+
+# sandboxed_api/bazel:filewrapper_test
+add_executable(filewrapper_test
+  filewrapper_test.cc
+)
+target_link_libraries(filewrapper_test PRIVATE
+  absl::strings
+  filewrapper_embedded
+  sandbox2::file_helpers
+  sandbox2::fileops
+  sandbox2::testing
+  sapi::test_main
+)
+gtest_discover_tests(filewrapper_test PROPERTIES
+  ENVIRONMENT TEST_TMPDIR=/tmp
+  ENVIRONMENT TEST_SRCDIR=${PROJECT_BINARY_DIR}
+)

--- a/sandboxed_api/bazel/external/libunwind.BUILD
+++ b/sandboxed_api/bazel/external/libunwind.BUILD
@@ -141,16 +141,16 @@ filegroup(
         "-Wno-cpp",
     ] + (
         ["-D{symbol}={symbol}_wrapped".format(symbol = symbol) for symbol in [
-            "ptrace",
-            "_UPT_create",
             "_UPT_accessors",
+            "_UPT_create",
             "_UPT_destroy",
             "_Ux86_64_create_addr_space",
             "_Ux86_64_destroy_addr_space",
-            "_Ux86_64_init_remote",
-            "_Ux86_64_step",
             "_Ux86_64_get_proc_name",
             "_Ux86_64_get_reg",
+            "_Ux86_64_init_remote",
+            "_Ux86_64_step",
+            "ptrace",
         ]] if do_wrap else []
     ),
     visibility = ["//visibility:public"],

--- a/sandboxed_api/sandbox2/CMakeLists.txt
+++ b/sandboxed_api/sandbox2/CMakeLists.txt
@@ -1,0 +1,862 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(testcases)
+add_subdirectory(unwind)
+add_subdirectory(util)
+
+# sandboxed_api/sandbox2:bpfdisassembler
+add_library(sandbox2_bpfdisassembler STATIC
+  bpfdisassembler.cc
+  bpfdisassembler.h
+)
+add_library(sandbox2::bpfdisassembler ALIAS sandbox2_bpfdisassembler)
+target_link_libraries(sandbox2_bpfdisassembler PRIVATE
+  absl::strings
+  sapi::base
+)
+
+# sandboxed_api/sandbox2:regs
+add_library(sandbox2_regs STATIC
+  regs.cc
+  regs.h
+)
+add_library(sandbox2::regs ALIAS sandbox2_regs)
+target_link_libraries(sandbox2_regs PRIVATE
+  absl::core_headers
+  absl::strings
+  sandbox2::strerror
+  sandbox2::syscall
+  sandbox2::violation_proto
+  sapi::base
+  sapi::status
+)
+
+# sandboxed_api/sandbox2:syscall
+add_library(sandbox2_syscall STATIC
+  syscall.cc
+  syscall.h
+  syscall_defs.cc
+  syscall_defs.h
+)
+add_library(sandbox2::syscall ALIAS sandbox2_syscall)
+target_link_libraries(sandbox2_syscall
+  PRIVATE absl::span
+          absl::str_format
+          absl::strings
+          sandbox2::util
+          sapi::base
+  PUBLIC  glog::glog
+)
+
+# sandboxed_api/sandbox2:syscall_test
+add_executable(syscall_test
+  syscall_test.cc
+)
+target_link_libraries(syscall_test PRIVATE
+  absl::strings
+  sandbox2::syscall
+  sapi::test_main
+)
+gtest_discover_tests(syscall_test)
+
+# sandboxed_api/sandbox2:result
+add_library(sandbox2_result STATIC
+  result.cc
+  result.h
+)
+add_library(sandbox2::result ALIAS sandbox2_result)
+target_link_libraries(sandbox2_result PRIVATE
+  absl::base
+  absl::memory
+  absl::strings
+  sandbox2::regs
+  sandbox2::syscall
+  sandbox2::util
+  sapi::base
+  sapi::status
+)
+
+# sandboxed_api/sandbox2:logserver_proto
+sapi_protobuf_generate_cpp(_sandbox2_logserver_pb_h _sandbox2_logserver_pb_cc
+  logserver.proto
+)
+add_library(sandbox2_logserver_proto STATIC
+  ${_sandbox2_logserver_pb_cc}
+  ${_sandbox2_logserver_pb_h}
+)
+add_library(sandbox2::logserver_proto ALIAS sandbox2_logserver_proto)
+target_link_libraries(sandbox2_logserver_proto PRIVATE
+  protobuf::libprotobuf
+  sapi::base
+)
+
+# sandboxed_api/sandbox2:logserver
+add_library(sandbox2_logserver STATIC
+  logserver.cc
+  logserver.h
+)
+add_library(sandbox2::logserver ALIAS sandbox2_logserver)
+target_link_libraries(sandbox2_logserver
+  PRIVATE absl::memory
+          sandbox2::comms
+          sandbox2::logserver_proto
+          sapi::base
+  PUBLIC  glog::glog
+)
+
+# sandboxed_api/sandbox2:logsink
+add_library(sandbox2_logsink STATIC
+  logsink.cc
+  logsink.h
+)
+add_library(sandbox2::logsink ALIAS sandbox2_logsink)
+target_link_libraries(sandbox2_logsink
+  PRIVATE absl::strings
+          absl::synchronization
+          sandbox2::comms
+          sandbox2::logserver_proto
+          sapi::base
+  PUBLIC  glog::glog
+)
+
+# sandboxed_api/sandbox2:network_proxy_server
+add_library(sandbox2_network_proxy_server STATIC
+  network_proxy_server.cc
+  network_proxy_server.h
+)
+add_library(sandbox2::network_proxy_server ALIAS sandbox2_network_proxy_server)
+target_link_libraries(sandbox2_network_proxy_server PRIVATE
+  absl::memory
+  glog::glog
+  sandbox2::comms
+  sandbox2::fileops
+  sapi::base
+)
+
+# sandboxed_api/sandbox2:network_proxy_client
+add_library(sandbox2_network_proxy_client STATIC
+  network_proxy_client.cc
+  network_proxy_client.h
+)
+add_library(sandbox2::network_proxy_client ALIAS sandbox2_network_proxy_client)
+target_link_libraries(sandbox2_network_proxy_client PRIVATE
+  absl::strings
+  absl::synchronization
+  glog::glog
+  sandbox2::comms
+  sandbox2::strerror
+  sapi::base
+  sapi::status
+)
+
+# sandboxed_api/sandbox2:ipc
+add_library(sandbox2_ipc STATIC
+  ipc.cc
+  ipc.h
+)
+add_library(sandbox2::ipc ALIAS sandbox2_ipc)
+target_link_libraries(sandbox2_ipc PRIVATE
+  absl::core_headers
+  absl::memory
+  absl::strings
+  sandbox2::comms
+  sandbox2::logserver
+  sandbox2::logsink
+  sandbox2::network_proxy_client
+  sandbox2::network_proxy_server
+  sapi::base
+)
+
+# sandboxed_api/sandbox2:policy
+add_library(sandbox2_policy STATIC
+  policy.cc
+  policy.h
+)
+add_library(sandbox2::policy ALIAS sandbox2_policy)
+target_link_libraries(sandbox2_policy PRIVATE
+  absl::core_headers
+  absl::optional
+  libcap::libcap
+  sandbox2::bpf_helper
+  sandbox2::bpfdisassembler
+  sandbox2::comms
+  sandbox2::namespace
+  sandbox2::regs
+  sandbox2::syscall
+  sandbox2::violation_proto
+  sapi::base
+  sapi::flag
+)
+
+# sandboxed_api/sandbox2:notify
+add_library(sandbox2_notify STATIC
+  notify.h
+)
+add_library(sandbox2::notify ALIAS sandbox2_notify)
+target_link_libraries(sandbox2_notify PRIVATE
+  sandbox2::comms
+  sandbox2::result
+  sandbox2::syscall
+  sapi::base
+)
+
+# sandboxed_api/sandbox2:limits
+add_library(sandbox2_limits STATIC
+  limits.h
+)
+add_library(sandbox2::limits ALIAS sandbox2_limits)
+target_link_libraries(sandbox2_limits PRIVATE
+  absl::core_headers
+  absl::time
+  sapi::base
+)
+
+# sandboxed_api/sandbox2:forkserver_bin
+add_executable(forkserver_bin  # Need unprefixed name here
+  forkserver_bin.cc
+)
+add_executable(sandbox2_forkserver_bin ALIAS forkserver_bin)
+add_executable(sandbox2::forkserver_bin ALIAS forkserver_bin)
+target_link_libraries(forkserver_bin PRIVATE
+  absl::core_headers
+  absl::strings
+  sandbox2::client
+  sandbox2::comms
+  sandbox2::forkserver
+  sandbox2::strerror
+  sapi::base
+  sapi::raw_logging
+)
+
+# sandboxed_api/sandbox2:forkserver_bin_embed
+sapi_cc_embed_data(NAME forkserver_bin_embed  # Need unprefixed name here
+  NAMESPACE ""
+  SOURCES forkserver_bin
+)
+add_library(sandbox2_forkserver_bin_embed ALIAS forkserver_bin_embed)
+add_library(sandbox2::forkserver_bin_embed ALIAS forkserver_bin_embed)
+
+# sandboxed_api/sandbox2:global_forkserver
+add_library(sandbox2_global_forkserver STATIC
+  global_forkclient.cc
+  global_forkclient.h
+)
+add_library(sandbox2::global_forkserver ALIAS sandbox2_global_forkserver)
+target_link_libraries(sandbox2_global_forkserver PRIVATE
+  absl::core_headers
+  absl::strings
+  sandbox2::client
+  sandbox2::comms
+  sandbox2::forkserver
+  sandbox2::forkserver_bin_embed
+  sandbox2::strerror
+  sapi::base
+  sapi::embed_file
+  sapi::raw_logging
+)
+
+# sandboxed_api/sandbox2:sandbox2
+add_library(sandbox2_sandbox2 STATIC
+  executor.cc
+  executor.h
+  monitor.cc
+  monitor.h
+  policybuilder.cc
+  policybuilder.h
+  sandbox2.cc
+  sandbox2.h
+  stack-trace.cc
+  stack-trace.h
+)
+add_library(sandbox2::sandbox2 ALIAS sandbox2_sandbox2)
+target_link_libraries(sandbox2_sandbox2
+  PRIVATE absl::core_headers
+          absl::flat_hash_map
+          absl::flat_hash_set
+          absl::memory
+          absl::optional
+          absl::str_format
+          absl::strings
+          absl::synchronization
+          absl::time
+          libcap::libcap
+          sandbox2::bpf_helper
+          sandbox2::client
+          sandbox2::comms
+          sandbox2::file_base
+          sandbox2::fileops
+          sandbox2::forkserver
+          sandbox2::forkserver_proto
+          sandbox2::global_forkserver
+          sandbox2::ipc
+          sandbox2::limits
+          sandbox2::mounts
+          sandbox2::namespace
+          sandbox2::network_proxy_client
+          sandbox2::notify
+          sandbox2::policy
+          sandbox2::ptrace_hook
+          sandbox2::regs
+          sandbox2::result
+          sandbox2::syscall
+          sandbox2::unwind
+          sandbox2::unwind_proto
+          sandbox2::util
+          sandbox2::violation_proto
+          sapi::base
+          sapi::status
+          sapi::statusor
+  PUBLIC  sapi::flag
+          sandbox2::logsink
+)
+
+# sandboxed_api/sandbox2:client
+add_library(sandbox2_client STATIC
+  client.cc
+  client.h
+  sanitizer.cc
+  sanitizer.h
+)
+add_library(sandbox2::client ALIAS sandbox2_client)
+target_link_libraries(sandbox2_client
+  PRIVATE absl::core_headers
+          absl::memory
+          absl::strings
+          sandbox2::comms
+          sandbox2::file_helpers
+          sandbox2::fileops
+          sandbox2::logsink
+          sandbox2::network_proxy_client
+          sandbox2::strerror
+          sapi::base
+          sapi::raw_logging
+  PUBLIC  glog::glog
+)
+
+# sandboxed_api/sandbox2:forkserver
+add_library(sandbox2_forkserver STATIC
+  forkserver.cc
+  forkserver.h
+)
+add_library(sandbox2::forkserver ALIAS sandbox2_forkserver)
+target_link_libraries(sandbox2_forkserver PRIVATE
+  absl::str_format
+  absl::strings
+  absl::synchronization
+  libcap::libcap
+  sandbox2::bpf_helper
+  sandbox2::client
+  sandbox2::comms
+  sandbox2::fileops
+  sandbox2::forkserver_proto
+  sandbox2::namespace
+  sandbox2::policy
+  sandbox2::ptrace_hook
+  sandbox2::strerror
+  sandbox2::syscall
+  sandbox2::unwind
+  sandbox2::unwind_proto
+  sandbox2::util
+  sapi::base
+  sapi::raw_logging
+)
+
+# sandboxed_api/sandbox2:mounts
+add_library(sandbox2_mounts STATIC
+  mounts.cc
+  mounts.h
+)
+add_library(sandbox2::mounts ALIAS sandbox2_mounts)
+target_link_libraries(sandbox2_mounts PRIVATE
+  absl::core_headers
+  absl::flat_hash_set
+  absl::str_format
+  absl::strings
+  protobuf::libprotobuf
+  sandbox2::file_base
+  sandbox2::fileops
+  sandbox2::minielf
+  sandbox2::mounttree_proto
+  sandbox2::strerror
+  sapi::base
+  sapi::raw_logging
+  sapi::status
+  sapi::statusor
+)
+
+# sandboxed_api/sandbox2:mounts_test
+add_executable(mounts_test
+  mounts_test.cc
+)
+add_dependencies(mounts_test
+  sandbox2::testcase_minimal_dynamic
+)
+target_link_libraries(mounts_test PRIVATE
+  absl::strings
+  sandbox2::file_base
+  sandbox2::mounts
+  sandbox2::temp_file
+  sandbox2::testing
+  sapi::status_matchers
+  sapi::test_main
+)
+gtest_discover_tests(mounts_test PROPERTIES
+  ENVIRONMENT "TEST_TMPDIR=/tmp"
+  ENVIRONMENT "TEST_SRCDIR=${PROJECT_BINARY_DIR}"
+)
+
+# sandboxed_api/sandbox2:namespace
+add_library(sandbox2_namespace STATIC
+  namespace.cc
+  namespace.h
+)
+add_library(sandbox2::namespace ALIAS sandbox2_namespace)
+target_link_libraries(sandbox2_namespace PRIVATE
+  absl::core_headers
+  absl::str_format
+  absl::strings
+  sandbox2::file_base
+  sandbox2::fileops
+  sandbox2::mounts
+  sandbox2::mounttree_proto
+  sandbox2::strerror
+  sandbox2::util
+  sandbox2::violation_proto
+  sapi::base
+  sapi::raw_logging
+)
+
+# sandboxed_api/sandbox2:namespace_test
+add_executable(namespace_test
+  namespace_test.cc
+)
+add_dependencies(mounts_test
+  sandbox2::testcase_hostname
+  sandbox2::testcase_namespace
+)
+target_link_libraries(namespace_test PRIVATE
+  absl::memory
+  absl::strings
+  sandbox2::comms
+  sandbox2::namespace
+  sandbox2::sandbox2
+  sandbox2::testing
+  sapi::status_matchers
+  sapi::test_main
+)
+gtest_discover_tests(namespace_test PROPERTIES
+  ENVIRONMENT "TEST_TMPDIR=/tmp"
+  ENVIRONMENT "TEST_SRCDIR=${PROJECT_BINARY_DIR}"
+)
+
+# sandboxed_api/sandbox2:forkingclient
+add_library(sandbox2_forkingclient STATIC
+  forkingclient.cc
+  forkingclient.h
+)
+add_library(sandbox2::forkingclient ALIAS sandbox2_forkingclient)
+target_link_libraries(sandbox2_forkingclient PRIVATE
+  absl::memory
+  sandbox2::client
+  sandbox2::forkserver
+  sapi::base
+)
+
+# sandboxed_api/sandbox2:util
+add_library(sandbox2_util STATIC
+  util.cc
+  util.h
+)
+add_library(sandbox2::util ALIAS sandbox2_util)
+target_link_libraries(sandbox2_util PRIVATE
+  absl::core_headers
+  absl::str_format
+  absl::strings
+  sandbox2::file_base
+  sandbox2::fileops
+  sandbox2::strerror
+  sapi::base
+  sapi::raw_logging
+  sapi::status
+  sapi::statusor
+)
+target_compile_options(sandbox2_util PRIVATE
+  # The default is 16384, however we need to do a clone with a
+  # stack-allocated buffer -- and PTHREAD_STACK_MIN also happens to be 16384.
+  # Thus the slight increase.
+  -Wframe-larger-than=17000
+)
+
+# sandboxed_api/sandbox2:buffer
+add_library(sandbox2_buffer STATIC
+  buffer.cc
+  buffer.h
+)
+add_library(sandbox2::buffer ALIAS sandbox2_buffer)
+target_link_libraries(sandbox2_buffer PRIVATE
+  absl::core_headers
+  absl::memory
+  absl::strings
+  sandbox2::strerror
+  sandbox2::util
+  sapi::base
+  sapi::status
+  sapi::statusor
+)
+
+# sandboxed_api/sandbox2:buffer_test
+add_executable(buffer_test
+  buffer_test.cc
+)
+add_dependencies(buffer_test
+  sandbox2::testcase_buffer
+)
+target_link_libraries(buffer_test PRIVATE
+  absl::memory
+  sandbox2::buffer
+  sandbox2::comms
+  sandbox2::sandbox2
+  sandbox2::testing
+  sapi::status_matchers
+  sapi::test_main
+)
+gtest_discover_tests(buffer_test)
+
+# sandboxed_api/sandbox2:forkserver_proto
+sapi_protobuf_generate_cpp(_sandbox2_forkserver_pb_h _sandbox2_forkserver_pb_cc
+  forkserver.proto
+)
+add_library(sandbox2_forkserver_proto STATIC
+  ${_sandbox2_forkserver_pb_cc}
+  ${_sandbox2_forkserver_pb_h}
+)
+add_library(sandbox2::forkserver_proto ALIAS sandbox2_forkserver_proto)
+target_link_libraries(sandbox2_forkserver_proto PRIVATE
+  protobuf::libprotobuf
+  sandbox2::mounttree_proto
+  sapi::base
+)
+
+# sandboxed_api/sandbox2:mounttree_proto
+sapi_protobuf_generate_cpp(_sandbox2_mounttree_pb_h _sandbox2_mounttree_pb_cc
+  mounttree.proto
+)
+add_library(sandbox2_mounttree_proto STATIC
+  ${_sandbox2_mounttree_pb_cc}
+  ${_sandbox2_mounttree_pb_h}
+)
+add_library(sandbox2::mounttree_proto ALIAS sandbox2_mounttree_proto)
+target_link_libraries(sandbox2_mounttree_proto PRIVATE
+  protobuf::libprotobuf
+  sapi::base
+)
+
+# sandboxed_api/sandbox2:comms
+add_library(sandbox2_comms STATIC
+  comms.cc
+  comms.h
+)
+add_library(sandbox2::comms ALIAS sandbox2_comms)
+target_link_libraries(sandbox2_comms PRIVATE
+  absl::core_headers
+  absl::memory
+  absl::str_format
+  absl::strings
+  absl::synchronization
+  protobuf::libprotobuf
+  sandbox2::strerror
+  sandbox2::util
+  sapi::base
+  sapi::raw_logging
+  sapi::status
+  sapi::status_proto
+  sapi::statusor
+)
+
+# sandboxed_api/sandbox2:comms_test_proto
+sapi_protobuf_generate_cpp(_sandbox2_comms_test_pb_h _sandbox2_comms_test_pb_cc
+  comms_test.proto
+)
+add_library(sandbox2_comms_test_proto STATIC
+  ${_sandbox2_comms_test_pb_cc}
+  ${_sandbox2_comms_test_pb_h}
+)
+add_library(sandbox2::comms_test_proto ALIAS sandbox2_comms_test_proto)
+target_link_libraries(sandbox2_comms_test_proto PRIVATE
+  protobuf::libprotobuf
+  sapi::base
+)
+
+# sandboxed_api/sandbox2:comms_test
+add_executable(comms_test
+  comms_test.cc
+)
+target_link_libraries(comms_test PRIVATE
+  absl::fixed_array
+  absl::strings
+  glog::glog
+  protobuf::libprotobuf
+  sandbox2::comms
+  sandbox2::comms_test_proto
+  sapi::status_matchers
+  sapi::test_main
+)
+gtest_discover_tests(comms_test)
+
+# sandboxed_api/sandbox2:forkserver_test
+add_executable(forkserver_test
+  forkserver_test.cc
+  global_forkclient.h
+)
+add_dependencies(forkserver_test
+  sandbox2::testcase_minimal
+)
+target_link_libraries(forkserver_test PRIVATE
+  absl::strings
+  glog::glog
+  sandbox2::comms
+  sandbox2::forkserver
+  sandbox2::forkserver_proto
+  sandbox2::sandbox2
+  sandbox2::testing
+  sapi::test_main
+)
+gtest_discover_tests(forkserver_test)
+
+# sandboxed_api/sandbox2:limits_test
+add_executable(limits_test
+  limits_test.cc
+)
+add_dependencies(limits_test
+  sandbox2::testcase_minimal
+)
+target_link_libraries(limits_test PRIVATE
+  absl::memory
+  sandbox2::bpf_helper
+  sandbox2::limits
+  sandbox2::sandbox2
+  sandbox2::testing
+  sapi::status_matchers
+  sapi::test_main
+)
+gtest_discover_tests(limits_test)
+
+# sandboxed_api/sandbox2:notify_test
+add_executable(notify_test
+  notify_test.cc
+)
+add_dependencies(notify_test
+  sandbox2::testcase_personality
+  sandbox2::testcase_pidcomms
+)
+target_link_libraries(notify_test PRIVATE
+  absl::memory
+  absl::strings
+  sandbox2::bpf_helper
+  sandbox2::comms
+  sandbox2::regs
+  sandbox2::sandbox2
+  sandbox2::testing
+  sapi::test_main
+)
+gtest_discover_tests(notify_test PROPERTIES
+  ENVIRONMENT "TEST_TMPDIR=/tmp"
+  ENVIRONMENT "TEST_SRCDIR=${PROJECT_BINARY_DIR}"
+)
+
+# sandboxed_api/sandbox2:policy_test
+add_executable(policy_test
+  policy_test.cc
+)
+add_dependencies(policy_test
+  sandbox2::testcase_add_policy_on_syscalls
+  sandbox2::testcase_malloc_system
+  sandbox2::testcase_minimal
+  sandbox2::testcase_minimal_dynamic
+  sandbox2::testcase_policy
+)
+target_link_libraries(policy_test PRIVATE
+  absl::memory
+  absl::strings
+  sandbox2::bpf_helper
+  sandbox2::limits
+  sandbox2::regs
+  sandbox2::sandbox2
+  sandbox2::testing
+  sapi::test_main
+)
+gtest_discover_tests(policy_test PROPERTIES
+  ENVIRONMENT "TEST_TMPDIR=/tmp"
+  ENVIRONMENT "TEST_SRCDIR=${PROJECT_BINARY_DIR}"
+)
+
+# sandboxed_api/sandbox2:sandbox2_test
+add_executable(sandbox2_test
+  sandbox2_test.cc
+)
+add_dependencies(sandbox2_test
+  sandbox2::testcase_abort
+  sandbox2::testcase_minimal
+  sandbox2::testcase_sleep
+  sandbox2::testcase_tsync
+)
+target_link_libraries(sandbox2_test PRIVATE
+  absl::memory
+  absl::strings
+  sandbox2::bpf_helper
+  sandbox2::sandbox2
+  sandbox2::testing
+  sapi::status_matchers
+  sapi::test_main
+)
+gtest_discover_tests(sandbox2_test PROPERTIES
+  ENVIRONMENT "TEST_TMPDIR=/tmp"
+  ENVIRONMENT "TEST_SRCDIR=${PROJECT_BINARY_DIR}"
+)
+
+# sandboxed_api/sandbox2:sanitizer_test
+add_executable(sanitizer_test
+  sanitizer_test.cc
+)
+add_dependencies(sanitizer_test
+  sandbox2::testcase_sanitizer
+)
+target_link_libraries(sanitizer_test PRIVATE
+  absl::memory
+  absl::strings
+  sandbox2::bpf_helper
+  sandbox2::client
+  sandbox2::comms
+  sandbox2::sandbox2
+  sandbox2::testing
+  sandbox2::util
+  sapi::status_matchers
+  sapi::test_main
+)
+gtest_discover_tests(sanitizer_test PROPERTIES
+  ENVIRONMENT "TEST_TMPDIR=/tmp"
+  ENVIRONMENT "TEST_SRCDIR=${PROJECT_BINARY_DIR}"
+)
+
+# sandboxed_api/sandbox2:util_test
+add_executable(util_test
+  util_test.cc
+)
+target_link_libraries(util_test PRIVATE
+  sandbox2::file_base
+  sandbox2::testing
+  sandbox2::util
+  sapi::test_main
+)
+gtest_discover_tests(util_test)
+
+# sandboxed_api/sandbox2:stack_trace_test
+add_executable(stack-trace_test
+  stack-trace_test.cc
+)
+add_dependencies(stack-trace_test
+  sandbox2::testcase_symbolize
+)
+target_link_libraries(stack-trace_test PRIVATE
+  absl::memory
+  absl::strings
+  sandbox2::bpf_helper
+  sandbox2::fileops
+  sandbox2::global_forkserver
+  sandbox2::sandbox2
+  sandbox2::temp_file
+  sandbox2::testing
+  sandbox2::util
+  sapi::status_matchers
+  sapi::test_main
+  sapi::flag
+)
+gtest_discover_tests(stack-trace_test PROPERTIES
+  ENVIRONMENT "TEST_TMPDIR=/tmp"
+  ENVIRONMENT "TEST_SRCDIR=${PROJECT_BINARY_DIR}"
+)
+
+# sandboxed_api/sandbox2:ipc_test
+add_executable(ipc_test
+  ipc_test.cc
+)
+add_dependencies(ipc_test
+  sandbox2::testcase_ipc
+)
+target_link_libraries(ipc_test PRIVATE
+  absl::memory
+  sandbox2::bpf_helper
+  sandbox2::comms
+  sandbox2::sandbox2
+  sandbox2::testing
+  sapi::status_matchers
+  sapi::test_main
+  sapi::flag
+)
+gtest_discover_tests(ipc_test PROPERTIES
+  ENVIRONMENT "TEST_TMPDIR=/tmp"
+  ENVIRONMENT "TEST_SRCDIR=${PROJECT_BINARY_DIR}"
+)
+
+# sandboxed_api/sandbox2:testing
+add_library(sandbox2_testing STATIC
+  testing.cc
+  testing.h
+)
+add_library(sandbox2::testing ALIAS sandbox2_testing)
+target_link_libraries(sandbox2_testing PRIVATE
+  absl::strings
+  sandbox2::file_base
+  sapi::base
+)
+
+# sandboxed_api/sandbox2:violation_proto
+sapi_protobuf_generate_cpp(_sandbox2_violation_pb_cc _sandbox2_violation_pb_h
+  violation.proto
+)
+add_library(sandbox2_violation_proto STATIC
+  ${_sandbox2_violation_pb_cc}
+  ${_sandbox2_violation_pb_h}
+)
+add_library(sandbox2::violation_proto ALIAS sandbox2_violation_proto)
+target_link_libraries(sandbox2_violation_proto PRIVATE
+  protobuf::libprotobuf
+  sandbox2::mounttree_proto
+  sapi::base
+)
+
+# sandboxed_api/sandbox2:policybuilder_test
+add_executable(policybuilder_test
+  policybuilder_test.cc
+)
+add_dependencies(policybuilder_test
+  sandbox2::testcase_print_fds
+)
+target_link_libraries(policybuilder_test PRIVATE
+  absl::memory
+  absl::strings
+  glog::glog
+  sandbox2::bpf_helper
+  sandbox2::comms
+  sandbox2::sandbox2
+  sandbox2::testing
+  sapi::status_matchers
+  sapi::test_main
+  sapi::flag
+)
+gtest_discover_tests(policybuilder_test PROPERTIES
+  ENVIRONMENT "TEST_TMPDIR=/tmp"
+  ENVIRONMENT "TEST_SRCDIR=${PROJECT_BINARY_DIR}"
+)

--- a/sandboxed_api/sandbox2/testcases/CMakeLists.txt
+++ b/sandboxed_api/sandbox2/testcases/CMakeLists.txt
@@ -1,0 +1,268 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(_sandbox2_testcase_properties
+  POSITION_INDEPENDENT_CODE ON
+)
+set(_sandbox2_fully_static_linkopts
+  -static
+  # Necessary for linking pthread statically into the binary. See the
+  # answer to https://stackoverflow.com/questions/35116327/ for context.
+  # The BUILD.bazel file in this directory also implements this.
+  -Wl,--whole-archive
+  -lpthread
+  -Wl,--no-whole-archive
+)
+
+# sandboxed_api/sandbox2/testcases:abort
+add_executable(abort
+  abort.cc
+)
+add_executable(sandbox2::testcase_abort ALIAS abort)
+target_link_libraries(abort PRIVATE
+  sapi::base
+  sapi::raw_logging
+)
+
+# sandboxed_api/sandbox2/testcases:add_policy_on_syscalls
+add_executable(add_policy_on_syscalls
+  add_policy_on_syscalls.cc
+)
+add_executable(sandbox2::testcase_add_policy_on_syscalls
+  ALIAS add_policy_on_syscalls)
+set_target_properties(add_policy_on_syscalls PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(add_policy_on_syscalls PRIVATE
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:buffer
+add_executable(buffer
+  buffer.cc
+)
+add_executable(sandbox2::testcase_buffer ALIAS buffer)
+set_target_properties(buffer PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(buffer PRIVATE
+  absl::str_format
+  sandbox2::buffer
+  sandbox2::comms
+  sapi::base
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:ipc
+add_executable(ipc
+  ipc.cc
+)
+add_executable(sandbox2::testcase_ipc ALIAS ipc)
+target_link_libraries(ipc PRIVATE
+  absl::strings
+  glog::glog
+  sandbox2::client
+  sandbox2::comms
+  sapi::base
+  sapi::raw_logging
+)
+
+# sandboxed_api/sandbox2/testcases:malloc_system
+add_executable(malloc_system
+  malloc.cc
+)
+add_executable(sandbox2::testcase_malloc_system ALIAS malloc_system)
+set_target_properties(malloc_system PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(malloc_system PRIVATE
+  sapi::base
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:minimal_dynamic
+add_executable(minimal_dynamic
+  minimal.cc
+)
+add_executable(sandbox2::testcase_minimal_dynamic ALIAS minimal_dynamic)
+target_link_libraries(minimal_dynamic PRIVATE
+  sapi::base
+)
+
+# sandboxed_api/sandbox2/testcases:minimal
+add_executable(minimal
+  minimal.cc
+)
+add_executable(sandbox2::testcase_minimal ALIAS minimal)
+set_target_properties(minimal PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(minimal PRIVATE
+  sapi::base
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:personality
+add_executable(personality
+  personality.cc
+)
+add_executable(sandbox2::testcase_personality ALIAS personality)
+set_target_properties(personality PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(personality PRIVATE
+  sapi::base
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:pidcomms
+add_executable(pidcomms
+  pidcomms.cc
+)
+add_executable(sandbox2::testcase_pidcomms ALIAS pidcomms)
+set_target_properties(pidcomms PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(pidcomms PRIVATE
+  glog::glog
+  sandbox2::client
+  sandbox2::comms
+  sapi::base
+  sapi::raw_logging
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:policy
+add_executable(policy
+  policy.cc
+)
+add_executable(sandbox2::testcase_policy ALIAS policy)
+set_target_properties(policy PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(policy PRIVATE
+  sapi::base
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:print_fds
+add_executable(print_fds
+  print_fds.cc
+)
+add_executable(sandbox2::testcase_print_fds ALIAS print_fds)
+set_target_properties(print_fds PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(print_fds PRIVATE
+  sapi::base
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:sanitizer
+add_executable(sanitizer
+  sanitizer.cc
+)
+add_executable(sandbox2::testcase_sanitizer ALIAS sanitizer)
+set_target_properties(sanitizer PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(sanitizer PRIVATE
+  sapi::base
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:sleep
+add_executable(sleep
+  sleep.cc
+)
+add_executable(sandbox2::testcase_sleep ALIAS sleep)
+set_target_properties(sleep PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(sleep PRIVATE
+  sapi::base
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:symbolize
+add_executable(symbolize
+  symbolize.cc
+)
+add_executable(sandbox2::testcase_symbolize ALIAS symbolize)
+set_target_properties(symbolize PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(symbolize PRIVATE
+  absl::core_headers
+  absl::strings
+  sandbox2::temp_file
+  sapi::base
+  sapi::raw_logging
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:tsync
+add_executable(tsync
+  tsync.cc
+)
+add_executable(sandbox2::testcase_tsync ALIAS tsync)
+set_target_properties(tsync PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(tsync PRIVATE
+  glog::glog
+  sapi::base
+  sandbox2::client
+  sandbox2::comms
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:hostname
+add_executable(hostname
+  hostname.cc
+)
+add_executable(sandbox2::testcase_hostname ALIAS hostname)
+set_target_properties(hostname PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(hostname PRIVATE
+  sapi::base
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:limits
+add_executable(limits
+  limits.cc
+)
+add_executable(sandbox2::testcase_limits ALIAS limits)
+set_target_properties(limits PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(limits PRIVATE
+  sapi::base
+  ${_sandbox2_fully_static_linkopts}
+)
+
+# sandboxed_api/sandbox2/testcases:namespace
+add_executable(namespace
+  namespace.cc
+)
+add_executable(sandbox2::testcase_namespace ALIAS namespace)
+set_target_properties(namespace PROPERTIES
+  ${_sandbox2_testcase_properties}
+)
+target_link_libraries(namespace PRIVATE
+  sapi::base
+  ${_sandbox2_fully_static_linkopts}
+)

--- a/sandboxed_api/sandbox2/unwind/BUILD.bazel
+++ b/sandboxed_api/sandbox2/unwind/BUILD.bazel
@@ -36,15 +36,15 @@ cc_library(
     ] + [
         "-D{symbol}={symbol}_wrapped".format(symbol = symbol)
         for symbol in [
-            "_UPT_create",
             "_UPT_accessors",
+            "_UPT_create",
             "_UPT_destroy",
             "_Ux86_64_create_addr_space",
             "_Ux86_64_destroy_addr_space",
-            "_Ux86_64_init_remote",
-            "_Ux86_64_step",
             "_Ux86_64_get_proc_name",
             "_Ux86_64_get_reg",
+            "_Ux86_64_init_remote",
+            "_Ux86_64_step",
         ]
     ],
     deps = [

--- a/sandboxed_api/sandbox2/unwind/CMakeLists.txt
+++ b/sandboxed_api/sandbox2/unwind/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# sandboxed_api/sandbox2/unwind:ptrace_hook
+add_library(sandbox2_ptrace_hook STATIC
+  ptrace_hook.cc
+  ptrace_hook.h
+)
+add_library(sandbox2::ptrace_hook ALIAS sandbox2_ptrace_hook)
+target_link_libraries(sandbox2_ptrace_hook PRIVATE
+  sapi::base
+)
+
+# sandboxed_api/sandbox2/unwind:unwind
+add_library(sandbox2_unwind STATIC
+  unwind.cc
+  unwind.h
+)
+add_library(sandbox2::unwind ALIAS sandbox2_unwind)
+target_link_libraries(sandbox2_unwind PRIVATE
+  sandbox2::comms
+  sandbox2::maps_parser
+  sandbox2::minielf
+  sandbox2::strerror
+  sandbox2::unwind_proto
+  sapi::base
+  sapi::raw_logging
+  unwind::unwind_ptrace_wrapped
+)
+
+# sandboxed_api/sandbox2/unwind:unwind_proto
+protobuf_generate_cpp(_sandbox2_unwind_pb_h _sandbox2_unwind_pb_cc
+  unwind.proto
+)
+add_library(sandbox2_unwind_proto STATIC
+  ${_sandbox2_unwind_pb_cc}
+  ${_sandbox2_unwind_pb_h}
+)
+add_library(sandbox2::unwind_proto ALIAS sandbox2_unwind_proto)
+target_link_libraries(sandbox2_unwind_proto PRIVATE
+  protobuf::libprotobuf
+  sapi::base
+)

--- a/sandboxed_api/sandbox2/util/CMakeLists.txt
+++ b/sandboxed_api/sandbox2/util/CMakeLists.txt
@@ -1,0 +1,219 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# sandboxed_api/sandbox2/util:bpf_helper
+add_library(sandbox2_util_bpf_helper STATIC
+  bpf_helper.c
+  bpf_helper.h
+)
+add_library(sandbox2::bpf_helper ALIAS sandbox2_util_bpf_helper)
+target_link_libraries(sandbox2_util_bpf_helper PRIVATE
+  sapi::base
+)
+
+# sandboxed_api/sandbox2/util:file_helpers
+add_library(sandbox2_util_file_helpers STATIC
+  file_helpers.cc
+  file_helpers.h
+)
+add_library(sandbox2::file_helpers ALIAS sandbox2_util_file_helpers)
+target_link_libraries(sandbox2_util_file_helpers PRIVATE
+  absl::strings
+  sapi::base
+  sapi::status
+)
+
+# sandboxed_api/sandbox2/util:file_helpers_test
+add_executable(file_helpers_test
+  file_helpers_test.cc
+)
+target_link_libraries(file_helpers_test PRIVATE
+  absl::strings
+  sandbox2::file_helpers
+  sapi::status_matchers
+  sapi::test_main
+)
+gtest_discover_tests(file_helpers_test)
+
+# sandboxed_api/sandbox2/util:fileops
+add_library(sandbox2_util_fileops STATIC
+  fileops.cc
+  fileops.h
+)
+add_library(sandbox2::fileops ALIAS sandbox2_util_fileops)
+target_link_libraries(sandbox2_util_fileops PRIVATE
+  absl::strings
+  sandbox2::strerror
+  sapi::base
+)
+
+# sandboxed_api/sandbox2/util:fileops_test
+add_executable(fileops_test
+  fileops_test.cc
+)
+target_link_libraries(fileops_test PRIVATE
+  absl::strings
+  sandbox2::file_helpers
+  sandbox2::fileops
+  sandbox2::testing
+  sapi::status_matchers
+  sapi::test_main
+)
+gtest_discover_tests(fileops_test PROPERTIES
+  ENVIRONMENT "TEST_TMPDIR=/tmp"
+  ENVIRONMENT "TEST_SRCDIR=${PROJECT_BINARY_DIR}"
+)
+
+# sandboxed_api/sandbox2/util:file_base
+add_library(sandbox2_util_file_base STATIC
+  path.cc
+  path.h
+)
+add_library(sandbox2::file_base ALIAS sandbox2_util_file_base)
+target_link_libraries(sandbox2_util_file_base PRIVATE
+  absl::strings
+  sapi::base
+)
+
+# sandboxed_api/sandbox2/util:file_base_test
+add_executable(file_base_test
+  path_test.cc
+)
+target_link_libraries(file_base_test PRIVATE
+  absl::strings
+  sandbox2::file_base
+  sapi::test_main
+)
+gtest_discover_tests(file_base_test)
+
+# sandboxed_api/sandbox2/util:strerror
+add_library(sandbox2_util_strerror STATIC
+  strerror.cc
+  strerror.h
+)
+add_library(sandbox2::strerror ALIAS sandbox2_util_strerror)
+target_link_libraries(sandbox2_util_strerror PRIVATE
+  absl::strings
+  sapi::base
+)
+
+# sandboxed_api/sandbox2/util:strerror
+add_executable(strerror_test
+  strerror_test.cc
+)
+target_link_libraries(strerror_test PRIVATE
+  absl::strings
+  sandbox2::strerror
+  sapi::test_main
+)
+gtest_discover_tests(strerror_test)
+
+# sandboxed_api/sandbox2/util:minielf
+add_library(sandbox2_util_minielf STATIC
+  minielf.cc
+  minielf.h
+)
+add_library(sandbox2::minielf ALIAS sandbox2_util_minielf)
+target_link_libraries(sandbox2_util_minielf PRIVATE
+  absl::strings
+  sandbox2::util
+  sapi::base
+  sapi::raw_logging
+  sapi::status
+  sapi::statusor
+)
+
+# sandboxed_api/sandbox2/util:minielf_test
+add_executable(minielf_test
+  minielf_test.cc
+)
+target_link_libraries(minielf_test PRIVATE
+  absl::strings
+  sandbox2::maps_parser
+  sandbox2::minielf
+  sandbox2::testing
+  sapi::test_main
+)
+gtest_discover_tests(minielf_test PROPERTIES
+  ENVIRONMENT TEST_TMPDIR=/tmp
+  ENVIRONMENT TEST_SRCDIR=${PROJECT_BINARY_DIR}
+)
+
+# sandboxed_api/sandbox2/util:temp_file
+add_library(sandbox2_util_temp_file STATIC
+  temp_file.cc
+  temp_file.h
+)
+add_library(sandbox2::temp_file ALIAS sandbox2_util_temp_file)
+target_link_libraries(sandbox2_util_temp_file PRIVATE
+  absl::strings
+  sandbox2::fileops
+  sandbox2::strerror
+  sapi::base
+  sapi::status
+  sapi::statusor
+)
+
+# sandboxed_api/sandbox2/util:temp_file_test
+add_executable(temp_file_test
+  temp_file_test.cc
+)
+target_link_libraries(temp_file_test PRIVATE
+  sandbox2::file_base
+  sandbox2::fileops
+  sandbox2::temp_file
+  sandbox2::testing
+  sapi::status_matchers
+  sapi::test_main
+)
+gtest_discover_tests(temp_file_test)
+
+# sandboxed_api/sandbox2/util:maps_parser
+add_library(sandbox2_util_maps_parser STATIC
+  maps_parser.cc
+  maps_parser.h
+)
+add_library(sandbox2::maps_parser ALIAS sandbox2_util_maps_parser)
+target_link_libraries(sandbox2_util_maps_parser PRIVATE
+  absl::strings
+  sapi::base
+  sapi::status
+  sapi::statusor
+)
+
+# sandboxed_api/sandbox2/util:maps_parser_test
+add_executable(maps_parser_test
+  maps_parser_test.cc
+)
+target_link_libraries(maps_parser_test PRIVATE
+  sandbox2::maps_parser
+  sapi::status_matchers
+  sapi::test_main
+)
+gtest_discover_tests(maps_parser_test)
+
+# sandboxed_api/sandbox2/util:runfiles
+add_library(sandbox2_util_runfiles STATIC
+  #runfiles.cc
+  runfiles.h
+)
+add_library(sandbox2::runfiles ALIAS sandbox2_util_runfiles)
+target_link_libraries(sandbox2_util_runfiles PRIVATE
+  absl::str_format
+  absl::strings
+  sandbox2::file_base
+  sapi::base
+  sapi::flag
+  sapi::raw_logging
+)

--- a/sandboxed_api/util/CMakeLists.txt
+++ b/sandboxed_api/util/CMakeLists.txt
@@ -1,0 +1,105 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# sandboxed_api/util:status_proto
+protobuf_generate_cpp(_sapi_util_status_pb_cc _sapi_util_status_pb_h
+  status.proto
+)
+add_library(sapi_util_status_proto STATIC
+  ${_sapi_util_status_pb_cc}
+  ${_sapi_util_status_pb_h}
+)
+add_library(sapi::status_proto ALIAS sapi_util_status_proto)
+target_link_libraries(sapi_util_status_proto PRIVATE
+  protobuf::libprotobuf
+)
+
+# sandboxed_api/util:status
+add_library(sapi_util_status STATIC
+  canonical_errors.cc
+  canonical_errors.h
+  status.cc
+  status.h
+  status_internal.h
+  status_macros.h
+)
+add_library(sapi::status ALIAS sapi_util_status)
+target_link_libraries(sapi_util_status PRIVATE
+  absl::core_headers
+  absl::strings
+  absl::type_traits
+  sapi::base
+  sapi::status_proto
+)
+
+# sandboxed_api/util:statusor
+add_library(sapi_util_statusor STATIC
+  statusor.h
+)
+add_library(sapi::statusor ALIAS sapi_util_statusor)
+target_link_libraries(sapi_util_statusor PRIVATE
+  absl::base
+  absl::core_headers
+  absl::variant
+  sapi::raw_logging
+  sapi::status
+)
+
+# sandboxed_api/util:status_matchers
+add_library(sapi_util_status_matchers STATIC
+  status_matchers.h
+)
+add_library(sapi::status_matchers ALIAS sapi_util_status_matchers)
+target_link_libraries(sapi_util_status_matchers PRIVATE
+  absl::optional
+  gmock
+  gtest
+  sapi::base
+  sapi::status
+  sapi::statusor
+)
+
+# sandboxed_api/util:status_test
+add_executable(status_test
+  status_test.cc
+)
+target_link_libraries(status_test PRIVATE
+  sapi::status_matchers
+  sapi::test_main
+  absl::type_traits
+)
+gtest_discover_tests(status_test)
+
+# sandboxed_api/util:flag
+add_library(sapi_util_flag STATIC
+  flag.h
+)
+add_library(sapi::flag ALIAS sapi_util_flag)
+target_link_libraries(sapi_util_flag PUBLIC
+  gflags
+)
+
+# sandboxed_api/util:raw_logging
+add_library(sapi_util_raw_logging STATIC
+  raw_logging.cc
+  raw_logging.h
+)
+add_library(sapi::raw_logging ALIAS sapi_util_raw_logging)
+target_link_libraries(sapi_util_raw_logging PRIVATE
+  absl::str_format
+  absl::strings
+  sandbox2::strerror
+  sapi::base
+)
+


### PR DESCRIPTION
- Add a superbuild in cmake/SuperBuild.cmake that downloads and builds
  dependencies
- Builds for sandbox2/ and a its tests
- Helper CMake function to strip proto paths
- Module to find libcap
- Custom build for libunwind that wraps its symbols
- Fix environment so that CTest executes tests similar to Bazel
- Filewrapper functionality, like Bazel's cc_embed_data()
- Build forkserver with embedded binary
- Enable ASM language so that libunwind builds correctly
- Allow glog target to propagate transitively (to propagate its include dirs)

Signed-off-by: Christian Blichmann <cblichmann@google.com>