### PR TITLE
Cache the location of Python 3 interpreter

### DIFF
--- a/cmake/SapiBuildDefs.cmake
+++ b/cmake/SapiBuildDefs.cmake
@@ -135,7 +135,7 @@ function(add_sapi_library)
   endif()
   add_custom_command(
     OUTPUT "${_sapi_gen_header}"
-    COMMAND "${Python3_EXECUTABLE}" -B
+    COMMAND "${SAPI_PYTHON3_EXECUTABLE}" -B
             "${SAPI_SOURCE_DIR}/sandboxed_api/tools/generator2/sapi_generator.py"
             "--sapi_name=${_sapi_LIBRARY_NAME}"
             "--sapi_out=${_sapi_gen_header}"

--- a/cmake/SapiDeps.cmake
+++ b/cmake/SapiDeps.cmake
@@ -77,7 +77,11 @@ find_package(Libffi REQUIRED)
 if(SAPI_ENABLE_EXAMPLES)
   find_package(ZLIB REQUIRED)
 endif()
+
+# Find Python 3 and add its location to the cache so that its available in
+# the add_sapi_library() macro in embedding projects.
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
+set(SAPI_PYTHON3_EXECUTABLE "${Python3_EXECUTABLE}" CACHE INTERNAL "" FORCE)
 
 # Undo global change
 set(CMAKE_FIND_LIBRARY_SUFFIXES ${_sapi_saved_CMAKE_FIND_LIBRARY_SUFFIXES})


### PR DESCRIPTION
Add the location of the Python 3 interpreter to the CMake cache so
that its available in the `add_sapi_library()` macro in downstream
embedding projects.

Signed-off-by: Christian Blichmann <mail@blichmann.eu>