### PR TITLE
Use common repository prefix everywhere

### DIFF
--- a/sandboxed_api/bazel/sapi.bzl
+++ b/sandboxed_api/bazel/sapi.bzl
@@ -155,10 +155,9 @@ def sapi_library(
         deps = [],
         tags = [],
         visibility = None):
-    """BUILD rule providing implementation of a Sandboxed API library."""
+    """Provides the implementation of a Sandboxed API library."""
 
-    repo_name = native.repository_name()
-    rprefix = "@com_google_sandboxed_api" if repo_name != "@" else ""
+    rprefix = "@com_google_sandboxed_api"
     common = {
         "tags": tags,
     }


### PR DESCRIPTION
Build macros in earlier versions of Bazel (pre-1.0) needed to specify
targets in a different format, depending from where they were
included/expanded at build time.

For example, a `sapi_library()` macro invocation in one of the directories
under `examples`, always needed to depend on the SAPI main library as
`//sandboxed_api:sapi`. When using SAPI from another Bazel project, the
same macro would have needed to depend on
`@com_google_sandboxed_api//sandboxed_api:sapi`. The `sapi_library()`
macro was thus checking the repository name and conditionally changed
the dependencies. This approach is brittle and as of Bazel 3.1.0 no
longer works.

This CL simple removes the conditional prefix and unconditionally uses
`@com_google_sandboxed_api`.

Tested on Bazel 1.2.1, 2.2.0 and 3.1.0