### PR TITLE
Support LLVM >= 7.0.1 in Clang based header generator

### DIFF
--- a/sandboxed_api/tools/clang_generator/CMakeLists.txt
+++ b/sandboxed_api/tools/clang_generator/CMakeLists.txt
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Minimum supported: LLVM 9
+# Minimum supported: LLVM 7.0.1
 find_package(LLVM REQUIRED)
 find_package(Clang REQUIRED)
+if(LLVM_VERSION VERSION_LESS "7.0.1")
+  message(FATAL_ERROR "SAPI header generator needs LLVM 7.0.1 or newer")
+endif()
 
 add_library(sapi_generator
   diagnostics.cc

--- a/sandboxed_api/tools/clang_generator/generator.h
+++ b/sandboxed_api/tools/clang_generator/generator.h
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "absl/container/flat_hash_set.h"
+#include "absl/memory/memory.h"
 #include "absl/status/status.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/RecursiveASTVisitor.h"
@@ -111,9 +112,15 @@ class GeneratorFactory : public clang::tooling::FrontendActionFactory {
       : options_(std::move(options)) {}
 
  private:
+#if LLVM_VERSION_MAJOR >= 10
+  std::unique_ptr<clang::FrontendAction> create() override {
+    return absl::make_unique<GeneratorAction>(&options_);
+  }
+#else
   clang::FrontendAction* create() override {
     return new GeneratorAction(&options_);
   }
+#endif
 
   GeneratorOptions options_;
 };


### PR DESCRIPTION
This change glosses over small API changes introduced since LLVM/Clang
7.0.1, which ships with Debian Stable "Buster". Ubuntu 18.04 LTS "Bionic"
also shipped this (and subsequently updated to version 9).

Hence, compiling the generator should now work on all reasonable Debian
based distributions.