### PR TITLE
Make build more robust

### DIFF
--- a/cmake/libffi/CMakeLists.txt.in
+++ b/cmake/libffi/CMakeLists.txt.in
@@ -20,9 +20,9 @@ ExternalProject_Add(libffi
   URL https://github.com/libffi/libffi/releases/download/v3.3-rc2/libffi-3.3-rc2.tar.gz
   URL_HASH SHA256=653ffdfc67fbb865f39c7e5df2a071c0beb17206ebfb0a9ecb18a18f63f6b263 # 2019-11-02
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/libffi-src"
-  CONFIGURE_COMMAND sh -c "./configure            \
-                    --disable-dependency-tracking \
-                    && (mv `sh config.guess` configure-cmake-gen || true)"
+  CONFIGURE_COMMAND ./configure
+                    --disable-dependency-tracking
+                    --disable-builddir
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""
   TEST_COMMAND      ""

--- a/cmake/libffi/Download.cmake
+++ b/cmake/libffi/Download.cmake
@@ -37,11 +37,11 @@ set(_ffi_src "${CMAKE_BINARY_DIR}/libffi-src")
 set(libffi_INCLUDE_DIR ${_ffi_src}/libffi/include)
 
 add_library(ffi STATIC
-  ${_ffi_src}/configure-cmake-gen/fficonfig.h
-  ${_ffi_src}/configure-cmake-gen/include/ffi.h
-  ${_ffi_src}/configure-cmake-gen/include/ffitarget.h
+  ${_ffi_src}/fficonfig.h
+  ${_ffi_src}/include/ffi.h
   ${_ffi_src}/include/ffi_cfi.h
   ${_ffi_src}/include/ffi_common.h
+  ${_ffi_src}/include/ffitarget.h
   ${_ffi_src}/src/closures.c
   ${_ffi_src}/src/debug.c
   ${_ffi_src}/src/java_raw_api.c
@@ -60,8 +60,7 @@ add_library(ffi STATIC
 )
 add_library(libffi::libffi ALIAS ffi)
 target_include_directories(ffi PUBLIC
-  ${_ffi_src}/configure-cmake-gen
-  ${_ffi_src}/configure-cmake-gen/include
+  ${_ffi_src}
   ${_ffi_src}/include
 )
 target_compile_options(ffi PRIVATE

--- a/cmake/zlib/Download.cmake
+++ b/cmake/zlib/Download.cmake
@@ -34,6 +34,7 @@ endif()
 
 set(_zlib_src "${CMAKE_BINARY_DIR}/zlib-src")
 
+set(ZLIB_FOUND TRUE)
 set(ZLIB_INCLUDE_DIRS ${_zlib_src})
 
 add_library(z STATIC

--- a/sandboxed_api/sandbox2/examples/zlib/CMakeLists.txt
+++ b/sandboxed_api/sandbox2/examples/zlib/CMakeLists.txt
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(ZLIB REQUIRED)
-
 # sandboxed_api/sandbox2/examples/zlib:zpipe_sandbox
 add_executable(sandbox2_zpipe_sandbox
   zpipe_sandbox.cc


### PR DESCRIPTION
This PR build libffi in-tree, so that we do not have architecture-dependent directory names anymore.
It also marks zlib as being found if we use our own CMake build for it.