### PR TITLE
Allow sandboxes to specify custom notifiers

### DIFF
--- a/sandboxed_api/sandbox.cc
+++ b/sandboxed_api/sandbox.cc
@@ -201,7 +201,8 @@ absl::Status Sandbox::Init() {
   ModifyExecutor(executor.get());
 
   s2_ = absl::make_unique<sandbox2::Sandbox2>(std::move(executor),
-                                              std::move(s2p));
+                                              std::move(s2p),
+                                              std::move(CreateNotifier()));
   auto res = s2_->RunAsync();
 
   comms_ = s2_->comms();

--- a/sandboxed_api/sandbox.cc
+++ b/sandboxed_api/sandbox.cc
@@ -201,8 +201,7 @@ absl::Status Sandbox::Init() {
   ModifyExecutor(executor.get());
 
   s2_ = absl::make_unique<sandbox2::Sandbox2>(std::move(executor),
-                                              std::move(s2p),
-                                              std::move(CreateNotifier()));
+                                              std::move(s2p), CreateNotifier());
   auto res = s2_->RunAsync();
 
   comms_ = s2_->comms();

--- a/sandboxed_api/sandbox.h
+++ b/sandboxed_api/sandbox.h
@@ -141,6 +141,11 @@ class Sandbox {
   // Modifies the Executor object if needed.
   virtual void ModifyExecutor(sandbox2::Executor* executor) {}
 
+  // Provides a custom notifier for sandboxee events. May return nullptr.
+  virtual std::unique_ptr<sandbox2::Notify> CreateNotifier() {
+      return nullptr;
+  }
+
   // Exits the sandboxee.
   void Exit() const;
 

--- a/sandboxed_api/sandbox.h
+++ b/sandboxed_api/sandbox.h
@@ -117,7 +117,6 @@ class Sandbox {
   absl::Status SetWallTimeLimit(time_t limit) const;
 
  protected:
-
   // Gets the arguments passed to the sandboxee.
   virtual void GetArgs(std::vector<std::string>* args) const {
     args->push_back("--logtostderr=true");
@@ -142,9 +141,7 @@ class Sandbox {
   virtual void ModifyExecutor(sandbox2::Executor* executor) {}
 
   // Provides a custom notifier for sandboxee events. May return nullptr.
-  virtual std::unique_ptr<sandbox2::Notify> CreateNotifier() {
-      return nullptr;
-  }
+  virtual std::unique_ptr<sandbox2::Notify> CreateNotifier() { return nullptr; }
 
   // Exits the sandboxee.
   void Exit() const;


### PR DESCRIPTION
This change is intended to allow users of SAPI to monitor the state of a running sandbox.