### PR TITLE
filewrapper: `_Exit` instead of `CHECK` failing

### DIFF
--- a/sandboxed_api/tools/filewrapper/filewrapper.cc
+++ b/sandboxed_api/tools/filewrapper/filewrapper.cc
@@ -97,7 +97,12 @@ class File {
   }
   ~File() { fclose(stream_); }
 
-  void Check() { SAPI_RAW_PCHECK(!ferror(stream_), "I/O on %s", name_); }
+  void Check() {
+    if (ferror(stream_)) {
+      SAPI_RAW_PLOG(ERROR, "I/O on %s", name_);
+      _Exit(EXIT_FAILURE);
+    }
+  }
 
   FILE* get() const { return stream_; }
 


### PR DESCRIPTION
Raw `SAPI_RAW_PCHECK` may dump core, depending on environment settings
(issue #89).
This is undesirable in the face of invalid command-line arguments.

Signed-off-by: Christian Blichmann <cblichmann@google.com>