### PR TITLE
CMake: Use min v3.13 and `FetchContent`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13..3.22)
 
 # Fix Ninja generator output to not rebuild entire sub-trees needlessly.
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/cmake/SapiFetchContent.cmake
+++ b/cmake/SapiFetchContent.cmake
@@ -1,0 +1,32 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(FetchContent)
+
+if(CMAKE_VERSION VERSION_LESS 3.14)
+  # Simple implementation for CMake 3.13, which is missing this.
+  macro(FetchContent_MakeAvailable)
+    foreach(content_name IN ITEMS ${ARGV})
+      string(TOLOWER ${content_name} content_name_lower)
+      FetchContent_GetProperties(${content_name})
+      if(NOT ${content_name_lower}_POPULATED)
+        FetchContent_Populate(${content_name})
+        if(EXISTS ${${content_name_lower}_SOURCE_DIR}/CMakeLists.txt)
+          add_subdirectory(${${content_name_lower}_SOURCE_DIR}
+                           ${${content_name_lower}_BINARY_DIR})
+        endif()
+      endif()
+    endforeach()
+  endmacro()
+endif()

--- a/cmake/abseil-cpp.cmake
+++ b/cmake/abseil-cpp.cmake
@@ -12,57 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(workdir "${CMAKE_BINARY_DIR}/_deps/absl-populate")
-
-set(SAPI_ABSL_GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
-                             CACHE STRING "")
-set(SAPI_ABSL_GIT_TAG d96e287417766deddbff2d01b96321288c59491e
-                      CACHE STRING "") # 2021-04-23
-set(SAPI_ABSL_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/absl-src" CACHE STRING "")
-set(SAPI_ABSL_BINARY_DIR "${CMAKE_BINARY_DIR}/_deps/absl-build" CACHE STRING "")
-
-file(WRITE "${workdir}/CMakeLists.txt" "\
-cmake_minimum_required(VERSION ${CMAKE_VERSION})
-project(absl-populate NONE)
-include(ExternalProject)
-ExternalProject_Add(absl
-  GIT_REPOSITORY    \"${SAPI_ABSL_GIT_REPOSITORY}\"
-  GIT_TAG           \"${SAPI_ABSL_GIT_TAG}\"
-  SOURCE_DIR        \"${SAPI_ABSL_SOURCE_DIR}\"
-  BINARY_DIR        \"${SAPI_ABSL_BINARY_DIR}\"
-  CONFIGURE_COMMAND \"\"
-  BUILD_COMMAND     \"\"
-  INSTALL_COMMAND   \"\"
-  TEST_COMMAND      \"\"
+FetchContent_Declare(absl
+  GIT_REPOSITORY https://github.com/abseil/abseil-cpp
+  GIT_TAG        d96e287417766deddbff2d01b96321288c59491e # 2021-04-23
 )
-")
-
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "CMake step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "Build step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
-set(_sapi_saved_BUILD_TESTING ${BUILD_TESTING})
-
 set(ABSL_CXX_STANDARD ${SAPI_CXX_STANDARD} CACHE STRING "" FORCE)
-set(ABSL_ENABLE_INSTALL ON CACHE BOOL "" FORCE)
 set(ABSL_PROPAGATE_CXX_STD ON CACHE BOOL "" FORCE)
 set(ABSL_RUN_TESTS OFF CACHE BOOL "" FORCE)
 set(ABSL_USE_GOOGLETEST_HEAD OFF CACHE BOOL "" FORCE)
-set(BUILD_TESTING OFF)  # Avoid errors when re-configuring SAPI
 
-add_subdirectory("${SAPI_ABSL_SOURCE_DIR}"
-                 "${SAPI_ABSL_BINARY_DIR}" EXCLUDE_FROM_ALL)
-
-if(_sapi_saved_BUILD_TESTING)
-  set(BUILD_TESTING "${_sapi_saved_BUILD_TESTING}")
-endif()
+FetchContent_MakeAvailable(absl)

--- a/cmake/benchmark.cmake
+++ b/cmake/benchmark.cmake
@@ -12,50 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(workdir "${CMAKE_BINARY_DIR}/_deps/benchmark-populate")
-
-set(SAPI_BENCHMARK_GIT_REPOSITORY https://github.com/google/benchmark.git
-                                  CACHE STRING "")
-set(SAPI_BENCHMARK_GIT_TAG 3b3de69400164013199ea448f051d94d7fc7d81f
-                           CACHE STRING "") # 2021-12-14
-set(SAPI_BENCHMARK_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/benchmark-src"
-                              CACHE STRING "")
-set(SAPI_BENCHMARK_BINARY_DIR "${CMAKE_BINARY_DIR}/_deps/benchmark-build"
-                              CACHE STRING "")
-
-file(WRITE "${workdir}/CMakeLists.txt" "\
-cmake_minimum_required(VERSION ${CMAKE_VERSION})
-project(benchmark-populate NONE)
-include(ExternalProject)
-ExternalProject_Add(benchmark
-  GIT_REPOSITORY    \"${SAPI_BENCHMARK_GIT_REPOSITORY}\"
-  GIT_TAG           \"${SAPI_BENCHMARK_GIT_TAG}\"
-  SOURCE_DIR        \"${SAPI_BENCHMARK_SOURCE_DIR}\"
-  BINARY_DIR        \"${SAPI_BENCHMARK_BINARY_DIR}\"
-  CONFIGURE_COMMAND \"\"
-  BUILD_COMMAND     \"\"
-  INSTALL_COMMAND   \"\"
-  TEST_COMMAND      \"\"
+FetchContent_Declare(benchmark
+  GIT_REPOSITORY https://github.com/google/benchmark.git
+  GIT_TAG        3b3de69400164013199ea448f051d94d7fc7d81f # 2021-12-14
 )
-")
-
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "CMake step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "Build step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
 set(BENCHMARK_ENABLE_TESTING OFF)
 set(BENCHMARK_ENABLE_EXCEPTIONS OFF)
 set(BENCHMARK_ENABLE_GTEST_TESTS OFF)
-
-add_subdirectory("${SAPI_BENCHMARK_SOURCE_DIR}"
-                 "${SAPI_BENCHMARK_BINARY_DIR}" EXCLUDE_FROM_ALL)
+FetchContent_MakeAvailable(benchmark)

--- a/cmake/gflags.cmake
+++ b/cmake/gflags.cmake
@@ -12,52 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(workdir "${CMAKE_BINARY_DIR}/_deps/gflags-populate")
-
-set(SAPI_GFLAGS_GIT_REPOSITORY https://github.com/gflags/gflags.git
-                               CACHE STRING "")
-set(SAPI_GFLAGS_GIT_TAG addd749114fab4f24b7ea1e0f2f837584389e52c
-                        CACHE STRING "") # 2020-03-18
-set(SAPI_GFLAGS_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/gflags-src"
-                            CACHE STRING "")
-set(SAPI_GFLAGS_BINARY_DIR "${CMAKE_BINARY_DIR}/_deps/gflags-build"
-                           CACHE STRING "")
-
-file(WRITE "${workdir}/CMakeLists.txt" "\
-cmake_minimum_required(VERSION ${CMAKE_VERSION})
-project(gflags-populate NONE)
-include(ExternalProject)
-ExternalProject_Add(gflags
-  GIT_REPOSITORY    \"${SAPI_GFLAGS_GIT_REPOSITORY}\"
-  GIT_TAG           \"${SAPI_GFLAGS_GIT_TAG}\"
-  SOURCE_DIR        \"${SAPI_GFLAGS_SOURCE_DIR}\"
-  BINARY_DIR        \"${SAPI_GFLAGS_BINARY_DIR}\"
-  CONFIGURE_COMMAND \"\"
-  BUILD_COMMAND     \"\"
-  INSTALL_COMMAND   \"\"
-  TEST_COMMAND      \"\"
+FetchContent_Declare(gflags
+  GIT_REPOSITORY https://github.com/gflags/gflags.git
+  GIT_TAG        addd749114fab4f24b7ea1e0f2f837584389e52c # 2020-03-18
 )
-")
-
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "CMake step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "Build step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
 set(GFLAGS_IS_SUBPROJECT TRUE)
 set(GFLAGS_BUILD_SHARED_LIBS ${SAPI_ENABLE_SHARED_LIBS})
 set(GFLAGS_INSTALL_SHARED_LIBS ${SAPI_ENABLE_SHARED_LIBS})
-set(GFLAGS_INSTALL_HEADERS OFF) # TODO: Temporary off
+set(GFLAGS_INSTALL_HEADERS OFF)
 set(GFLAGS_BUILD_TESTING FALSE)
 
-add_subdirectory("${SAPI_GFLAGS_SOURCE_DIR}"
-                 "${SAPI_GFLAGS_BINARY_DIR}" EXCLUDE_FROM_ALL)
+FetchContent_MakeAvailable(gflags)

--- a/cmake/glog.cmake
+++ b/cmake/glog.cmake
@@ -12,81 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Allows use target_link_libraries() with targets in other directories.
-if(POLICY CMP0079)
-  cmake_policy(SET CMP0079 NEW)
-endif()
-
-set(workdir "${CMAKE_BINARY_DIR}/_deps/glog-populate")
-
-set(SAPI_GLOG_GIT_REPOSITORY https://github.com/google/glog.git CACHE STRING "")
-set(SAPI_GLOG_GIT_TAG 3ba8976592274bc1f907c402ce22558011d6fc5e
-                      CACHE STRING "") # 2020-02-16
-set(SAPI_GLOG_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/glog-src" CACHE STRING "")
-set(SAPI_GLOG_BINARY_DIR "${CMAKE_BINARY_DIR}/_deps/glog-build" CACHE STRING "")
-
-file(WRITE "${workdir}/CMakeLists.txt" "\
-cmake_minimum_required(VERSION ${CMAKE_VERSION})
-project(glog-populate NONE)
-include(ExternalProject)
-ExternalProject_Add(glog
-  GIT_REPOSITORY    \"${SAPI_GLOG_GIT_REPOSITORY}\"
-  GIT_TAG           \"${SAPI_GLOG_GIT_TAG}\"
-  SOURCE_DIR        \"${SAPI_GLOG_SOURCE_DIR}\"
-  BINARY_DIR        \"${SAPI_GLOG_BINARY_DIR}\"
-  CONFIGURE_COMMAND \"\"
-  BUILD_COMMAND     \"\"
-  INSTALL_COMMAND   \"\"
-  TEST_COMMAND      \"\"
+FetchContent_Declare(glog
+  GIT_REPOSITORY https://github.com/google/glog.git
+  GIT_TAG        3ba8976592274bc1f907c402ce22558011d6fc5e # 2020-02-16
 )
-")
-
-execute_process(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "CMake step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
-execute_process(COMMAND "${CMAKE_COMMAND}" --build .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "Build step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
-set(_sapi_saved_BUILD_TESTING ${BUILD_TESTING})
-
 # Force gflags from subdirectory
 set(WITH_GFLAGS FALSE CACHE BOOL "" FORCE)
 set(HAVE_LIB_GFLAGS TRUE CACHE STRING "" FORCE)
 
 set(WITH_UNWIND FALSE CACHE BOOL "" FORCE)
 set(UNWIND_LIBRARY FALSE)
-set(HAVE_PWD_H FALSE)
 
+set(HAVE_PWD_H FALSE)
 set(WITH_PKGCONFIG TRUE CACHE BOOL "" FORCE)
 
-set(BUILD_TESTING FALSE)
 set(BUILD_SHARED_LIBS ${SAPI_ENABLE_SHARED_LIBS})
 
-add_subdirectory("${SAPI_GLOG_SOURCE_DIR}"
-                 "${SAPI_GLOG_BINARY_DIR}" EXCLUDE_FROM_ALL)
-
+FetchContent_MakeAvailable(glog)
 target_include_directories(glog PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/_deps/gflags-build/include>
-  $<BUILD_INTERFACE:${SAPI_GLOG_BINARY_DIR}>
+  $<BUILD_INTERFACE:${gflags_BINARY_DIR}/include>
+  $<BUILD_INTERFACE:${gflags_BINARY_DIR}>
 )
 add_library(gflags_nothreads STATIC IMPORTED)
 set_target_properties(gflags_nothreads PROPERTIES
-  IMPORTED_LOCATION
-  "${CMAKE_BINARY_DIR}/_deps/gflags-build/libgflags_nothreads.a")
-target_link_libraries(glog PRIVATE
-  -Wl,--whole-archive
-  gflags_nothreads
-  -Wl,--no-whole-archive
+  IMPORTED_LOCATION "${gflags_BINARY_DIR}/libgflags_nothreads.a"
 )
-
-if(_sapi_saved_BUILD_TESTING)
-  set(BUILD_TESTING "${_sapi_saved_BUILD_TESTING}")
-endif()
+target_link_libraries(glog PRIVATE
+  -Wl,--whole-archive gflags_nothreads -Wl,--no-whole-archive
+)

--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -12,48 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(workdir "${CMAKE_BINARY_DIR}/_deps/googletest-populate")
-
-set(SAPI_GOOGLETEST_GIT_REPOSITORY https://github.com/google/googletest.git
-                                   CACHE STRING "")
-set(SAPI_GOOGLETEST_GIT_TAG 9a32aee22d771387c494be2d8519fbdf46a713b2
-                            CACHE STRING "") # 2021-12-20
-set(SAPI_GOOGLETEST_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/googletest-src"
-                               CACHE STRING "")
-set(SAPI_GOOGLETEST_BINARY_DIR "${CMAKE_BINARY_DIR}/_deps/googletest-build"
-                               CACHE STRING "")
-
-file(WRITE "${workdir}/CMakeLists.txt" "\
-cmake_minimum_required(VERSION ${CMAKE_VERSION})
-project(googletest-populate NONE)
-include(ExternalProject)
-ExternalProject_Add(googletest
-  GIT_REPOSITORY    \"${SAPI_GOOGLETEST_GIT_REPOSITORY}\"
-  GIT_TAG           \"${SAPI_GOOGLETEST_GIT_TAG}\"
-  SOURCE_DIR        \"${SAPI_GOOGLETEST_SOURCE_DIR}\"
-  BINARY_DIR        \"${SAPI_GOOGLETEST_BINARY_DIR}\"
-  CONFIGURE_COMMAND \"\"
-  BUILD_COMMAND     \"\"
-  INSTALL_COMMAND   \"\"
-  TEST_COMMAND      \"\"
+FetchContent_Declare(googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        9a32aee22d771387c494be2d8519fbdf46a713b2 # 2021-12-20
 )
-")
-
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "CMake step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "Build step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-
-add_subdirectory("${SAPI_GOOGLETEST_SOURCE_DIR}"
-                 "${SAPI_GOOGLETEST_BINARY_DIR}" EXCLUDE_FROM_ALL)
+FetchContent_MakeAvailable(googletest)

--- a/cmake/libcap.cmake
+++ b/cmake/libcap.cmake
@@ -12,108 +12,71 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(workdir "${CMAKE_BINARY_DIR}/_deps/libcap-populate")
-
-set(SAPI_LIBCAP_URL
-  https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.27.tar.gz
-  CACHE STRING "")
-set(SAPI_LIBCAP_URL_HASH
-  SHA256=260b549c154b07c3cdc16b9ccc93c04633c39f4fb6a4a3b8d1fa5b8a9c3f5fe8
-  CACHE STRING "") # 2019-04-16
-set(SAPI_LIBCAP_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/libcap-src"
-                           CACHE STRING "")
-set(SAPI_LIBCAP_BINARY_DIR "${CMAKE_BINARY_DIR}/_deps/libcap-build"
-                           CACHE STRING "")
-
-file(WRITE "${workdir}/CMakeLists.txt" "\
-cmake_minimum_required(VERSION ${CMAKE_VERSION})
-project(libcap-populate NONE)
-include(ExternalProject)
-ExternalProject_Add(libcap
-  URL               \"${SAPI_LIBCAP_URL}\"
-  URL_HASH          \"${SAPI_LIBCAP_URL_HASH}\"
-  SOURCE_DIR        \"${SAPI_LIBCAP_SOURCE_DIR}\"
-  BINARY_DIR        \"${SAPI_LIBCAP_BINARY_DIR}\"
-  CONFIGURE_COMMAND \"\"
-  BUILD_COMMAND     \"\"
-  INSTALL_COMMAND   \"\"
-  TEST_COMMAND      \"\"
+FetchContent_Declare(libcap
+  URL      https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.27.tar.gz
+  URL_HASH SHA256=260b549c154b07c3cdc16b9ccc93c04633c39f4fb6a4a3b8d1fa5b8a9c3f5fe8
 )
-")
+FetchContent_MakeAvailable(libcap)
 
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "CMake step for ${PROJECT_NAME} failed: ${error}")
-endif()
+set(libcap_INCLUDE_DIR "${libcap_SOURCE_DIR}/libcap/include")
 
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "Build step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
-set(libcap_INCLUDE_DIR "${SAPI_LIBCAP_SOURCE_DIR}/libcap/include")
-
-add_custom_command(OUTPUT ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_names.list.h
+add_custom_command(OUTPUT ${libcap_SOURCE_DIR}/libcap/cap_names.list.h
   VERBATIM
   COMMAND # Use the same logic as libcap/Makefile
   sed -ne [=[/^#define[ \\t]CAP[_A-Z]\+[ \\t]\+[0-9]\+/{s/^#define \([^ \\t]*\)[ \\t]*\([^ \\t]*\)/\{\"\1\",\2\},/p;}]=]
-      ${SAPI_LIBCAP_SOURCE_DIR}/libcap/include/uapi/linux/capability.h |
-  tr [:upper:] [:lower:] > ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_names.list.h
+      ${libcap_SOURCE_DIR}/libcap/include/uapi/linux/capability.h |
+  tr [:upper:] [:lower:] > ${libcap_SOURCE_DIR}/libcap/cap_names.list.h
 )
 
 if (CMAKE_CROSSCOMPILING AND BUILD_C_COMPILER)
-  add_custom_command(OUTPUT ${SAPI_LIBCAP_SOURCE_DIR}/libcap/libcap_makenames
+  add_custom_command(OUTPUT ${libcap_SOURCE_DIR}/libcap/libcap_makenames
     VERBATIM
     # Use the same logic as libcap/Makefile
     COMMAND ${BUILD_C_COMPILER} ${BUILD_C_FLAGS}
-                ${SAPI_LIBCAP_SOURCE_DIR}/libcap/_makenames.c
-                -o ${SAPI_LIBCAP_SOURCE_DIR}/libcap/libcap_makenames
-    DEPENDS ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_names.list.h
-            ${SAPI_LIBCAP_SOURCE_DIR}/libcap/_makenames.c
+                ${libcap_SOURCE_DIR}/libcap/_makenames.c
+                -o ${libcap_SOURCE_DIR}/libcap/libcap_makenames
+    DEPENDS ${libcap_SOURCE_DIR}/libcap/cap_names.list.h
+            ${libcap_SOURCE_DIR}/libcap/_makenames.c
   )
 
-  add_custom_command(OUTPUT ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_names.h
-    COMMAND ${SAPI_LIBCAP_SOURCE_DIR}/libcap/libcap_makenames >
-                ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_names.h
-    DEPENDS ${SAPI_LIBCAP_SOURCE_DIR}/libcap/libcap_makenames
+  add_custom_command(OUTPUT ${libcap_SOURCE_DIR}/libcap/cap_names.h
+    COMMAND ${libcap_SOURCE_DIR}/libcap/libcap_makenames >
+                ${libcap_SOURCE_DIR}/libcap/cap_names.h
+    DEPENDS ${libcap_SOURCE_DIR}/libcap/libcap_makenames
   )
 else()
   add_executable(libcap_makenames
-    ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_names.list.h
-    ${SAPI_LIBCAP_SOURCE_DIR}/libcap/_makenames.c
+    ${libcap_SOURCE_DIR}/libcap/cap_names.list.h
+    ${libcap_SOURCE_DIR}/libcap/_makenames.c
   )
 
   target_include_directories(libcap_makenames PUBLIC
-    ${SAPI_LIBCAP_SOURCE_DIR}/libcap
-    ${SAPI_LIBCAP_SOURCE_DIR}/libcap/include
-    ${SAPI_LIBCAP_SOURCE_DIR}/libcap/include/uapi
+    ${libcap_SOURCE_DIR}/libcap
+    ${libcap_SOURCE_DIR}/libcap/include
+    ${libcap_SOURCE_DIR}/libcap/include/uapi
   )
 
-  add_custom_command(OUTPUT ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_names.h
-    COMMAND libcap_makenames > ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_names.h
+  add_custom_command(OUTPUT ${libcap_SOURCE_DIR}/libcap/cap_names.h
+    COMMAND libcap_makenames > ${libcap_SOURCE_DIR}/libcap/cap_names.h
   )
 endif()
 
 add_library(cap STATIC
-  ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_alloc.c
-  ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_extint.c
-  ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_file.c
-  ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_flag.c
-  ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_names.h
-  ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_proc.c
-  ${SAPI_LIBCAP_SOURCE_DIR}/libcap/cap_text.c
-  ${SAPI_LIBCAP_SOURCE_DIR}/libcap/include/uapi/linux/capability.h
-  ${SAPI_LIBCAP_SOURCE_DIR}/libcap/libcap.h
+  ${libcap_SOURCE_DIR}/libcap/cap_alloc.c
+  ${libcap_SOURCE_DIR}/libcap/cap_extint.c
+  ${libcap_SOURCE_DIR}/libcap/cap_file.c
+  ${libcap_SOURCE_DIR}/libcap/cap_flag.c
+  ${libcap_SOURCE_DIR}/libcap/cap_names.h
+  ${libcap_SOURCE_DIR}/libcap/cap_proc.c
+  ${libcap_SOURCE_DIR}/libcap/cap_text.c
+  ${libcap_SOURCE_DIR}/libcap/include/uapi/linux/capability.h
+  ${libcap_SOURCE_DIR}/libcap/libcap.h
 )
 add_library(libcap::libcap ALIAS cap)
 target_include_directories(cap PUBLIC
-  ${SAPI_LIBCAP_SOURCE_DIR}/libcap
-  ${SAPI_LIBCAP_SOURCE_DIR}/libcap/include
-  ${SAPI_LIBCAP_SOURCE_DIR}/libcap/include/uapi
+  ${libcap_SOURCE_DIR}/libcap
+  ${libcap_SOURCE_DIR}/libcap/include
+  ${libcap_SOURCE_DIR}/libcap/include/uapi
 )
 target_compile_options(cap PRIVATE
   -Wno-tautological-compare

--- a/cmake/libffi.cmake
+++ b/cmake/libffi.cmake
@@ -12,105 +12,87 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(workdir "${CMAKE_BINARY_DIR}/_deps/libffi-populate")
-
-set(SAPI_LIBFFI_URL
-  https://github.com/libffi/libffi/releases/download/v3.3-rc2/libffi-3.3-rc2.tar.gz
-  CACHE STRING "")
-set(SAPI_LIBFFI_URL_HASH
-  SHA256=653ffdfc67fbb865f39c7e5df2a071c0beb17206ebfb0a9ecb18a18f63f6b263
-  CACHE STRING "") # 2019-11-02
-set(SAPI_LIBFFI_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/libffi-src"
-                           CACHE STRING "")
-set(SAPI_LIBFFI_BINARY_DIR "${CMAKE_BINARY_DIR}/_deps/libffi-build"
-                           CACHE STRING "")
-
-file(WRITE "${workdir}/CMakeLists.txt" "\
-cmake_minimum_required(VERSION ${CMAKE_VERSION})
-project(libffi-populate NONE)
-include(ExternalProject)
-ExternalProject_Add(libffi
-  URL               \"${SAPI_LIBFFI_URL}\"
-  URL_HASH          \"${SAPI_LIBFFI_URL_HASH}\"
-  SOURCE_DIR        \"${SAPI_LIBFFI_SOURCE_DIR}\"
-  CONFIGURE_COMMAND ./configure
-                    --disable-dependency-tracking
-                    --disable-builddir
-                    ${SAPI_THIRD_PARTY_CONFIGUREOPTS}
-  BUILD_COMMAND     \"\"
-  INSTALL_COMMAND   \"\"
-  TEST_COMMAND      \"\"
-  BUILD_IN_SOURCE TRUE
+FetchContent_Declare(libffi
+  URL      https://github.com/libffi/libffi/releases/download/v3.3-rc2/libffi-3.3-rc2.tar.gz
+  URL_HASH SHA256=653ffdfc67fbb865f39c7e5df2a071c0beb17206ebfb0a9ecb18a18f63f6b263
 )
-")
-
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "CMake step for ${PROJECT_NAME} failed: ${error}")
+FetchContent_GetProperties(libffi)
+if(NOT libffi_POPULATED)
+  FetchContent_Populate(libffi)
+  set(libffi_STATUS_FILE "${libffi_SOURCE_DIR}/config.status")
+  if(EXISTS "${libffi_STATUS_FILE}")
+    file(SHA256 "${libffi_STATUS_FILE}" _sapi_CONFIG_STATUS)
+  endif()
+  if(NOT _sapi_CONFIG_STATUS STREQUAL "${libffi_CONFIG_STATUS}")
+    message("-- Running ./configure for libffi...")
+    execute_process(
+      COMMAND ./configure --disable-dependency-tracking
+                          --disable-builddir
+                          --quiet
+      WORKING_DIRECTORY "${libffi_SOURCE_DIR}"
+      RESULT_VARIABLE _sapi_libffi_config_result
+    )
+    if(NOT _sapi_libffi_config_result EQUAL "0")
+      message(FATAL_ERROR "Configuration of libffi dependency failed")
+    endif()
+    file(SHA256 "${libffi_SOURCE_DIR}/config.status" _sapi_CONFIG_STATUS)
+    set(libffi_CONFIG_STATUS "${_sapi_CONFIG_STATUS}" CACHE INTERNAL "")
+  endif()
 endif()
 
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "Build step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
-set(libffi_INCLUDE_DIR ${SAPI_LIBFFI_SOURCE_DIR}/libffi/include)
+set(libffi_INCLUDE_DIR ${libffi_SOURCE_DIR}/libffi/include)
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
   list(APPEND _ffi_platform_srcs
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/x86/asmnames.h
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/x86/ffi.c
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/x86/ffi64.c
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/x86/ffiw64.c
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/x86/internal.h
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/x86/internal64.h
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/x86/sysv.S
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/x86/unix64.S
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/x86/win64.S
+    ${libffi_SOURCE_DIR}/src/x86/asmnames.h
+    ${libffi_SOURCE_DIR}/src/x86/ffi.c
+    ${libffi_SOURCE_DIR}/src/x86/ffi64.c
+    ${libffi_SOURCE_DIR}/src/x86/ffiw64.c
+    ${libffi_SOURCE_DIR}/src/x86/internal.h
+    ${libffi_SOURCE_DIR}/src/x86/internal64.h
+    ${libffi_SOURCE_DIR}/src/x86/sysv.S
+    ${libffi_SOURCE_DIR}/src/x86/unix64.S
+    ${libffi_SOURCE_DIR}/src/x86/win64.S
   )
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64")
   list(APPEND _ffi_platform_srcs
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/powerpc/ffi.c
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/powerpc/ffi_linux64.c
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/powerpc/ffi_sysv.c
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/powerpc/linux64.S
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/powerpc/linux64_closure.S
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/powerpc/ppc_closure.S
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/powerpc/sysv.S
+    ${libffi_SOURCE_DIR}/src/powerpc/ffi.c
+    ${libffi_SOURCE_DIR}/src/powerpc/ffi_linux64.c
+    ${libffi_SOURCE_DIR}/src/powerpc/ffi_sysv.c
+    ${libffi_SOURCE_DIR}/src/powerpc/linux64.S
+    ${libffi_SOURCE_DIR}/src/powerpc/linux64_closure.S
+    ${libffi_SOURCE_DIR}/src/powerpc/ppc_closure.S
+    ${libffi_SOURCE_DIR}/src/powerpc/sysv.S
     # Textual headers
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/powerpc/ffi_powerpc.h
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/powerpc/asm.h
+    ${libffi_SOURCE_DIR}/src/powerpc/ffi_powerpc.h
+    ${libffi_SOURCE_DIR}/src/powerpc/asm.h
   )
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
   list(APPEND _ffi_platform_srcs
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/aarch64/ffi.c
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/aarch64/internal.h
-    ${SAPI_LIBFFI_SOURCE_DIR}/src/aarch64/sysv.S
+    ${libffi_SOURCE_DIR}/src/aarch64/ffi.c
+    ${libffi_SOURCE_DIR}/src/aarch64/internal.h
+    ${libffi_SOURCE_DIR}/src/aarch64/sysv.S
   )
 endif()
 
 add_library(ffi STATIC
-  ${SAPI_LIBFFI_SOURCE_DIR}/fficonfig.h
-  ${SAPI_LIBFFI_SOURCE_DIR}/include/ffi.h
-  ${SAPI_LIBFFI_SOURCE_DIR}/include/ffi_cfi.h
-  ${SAPI_LIBFFI_SOURCE_DIR}/include/ffi_common.h
-  ${SAPI_LIBFFI_SOURCE_DIR}/include/ffitarget.h
-  ${SAPI_LIBFFI_SOURCE_DIR}/src/closures.c
-  ${SAPI_LIBFFI_SOURCE_DIR}/src/debug.c
-  ${SAPI_LIBFFI_SOURCE_DIR}/src/java_raw_api.c
-  ${SAPI_LIBFFI_SOURCE_DIR}/src/prep_cif.c
-  ${SAPI_LIBFFI_SOURCE_DIR}/src/raw_api.c
-  ${SAPI_LIBFFI_SOURCE_DIR}/src/types.c
+  ${libffi_SOURCE_DIR}/fficonfig.h
+  ${libffi_SOURCE_DIR}/include/ffi.h
+  ${libffi_SOURCE_DIR}/include/ffi_cfi.h
+  ${libffi_SOURCE_DIR}/include/ffi_common.h
+  ${libffi_SOURCE_DIR}/include/ffitarget.h
+  ${libffi_SOURCE_DIR}/src/closures.c
+  ${libffi_SOURCE_DIR}/src/debug.c
+  ${libffi_SOURCE_DIR}/src/java_raw_api.c
+  ${libffi_SOURCE_DIR}/src/prep_cif.c
+  ${libffi_SOURCE_DIR}/src/raw_api.c
+  ${libffi_SOURCE_DIR}/src/types.c
   ${_ffi_platform_srcs}
 )
 add_library(libffi::libffi ALIAS ffi)
 target_include_directories(ffi PUBLIC
-  ${SAPI_LIBFFI_SOURCE_DIR}
-  ${SAPI_LIBFFI_SOURCE_DIR}/include
+  ${libffi_SOURCE_DIR}
+  ${libffi_SOURCE_DIR}/include
 )
 target_compile_options(ffi PRIVATE
   -Wno-vla

--- a/cmake/libunwind.cmake
+++ b/cmake/libunwind.cmake
@@ -12,204 +12,185 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(workdir "${CMAKE_BINARY_DIR}/_deps/libunwind-populate")
-
-set(SAPI_LIBUNWIND_URL
-  https://github.com/libunwind/libunwind/releases/download/v1.6.2/libunwind-1.6.2.tar.gz
-  CACHE STRING "")
-set(SAPI_LIBUNWIND_URL_HASH
-  SHA256=4a6aec666991fb45d0889c44aede8ad6eb108071c3554fcdff671f9c94794976
-  CACHE STRING "")
-set(SAPI_LIBUNWIND_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/libunwind-src"
-                              CACHE STRING "")
-set(SAPI_LIBUNWIND_BINARY_DIR "${CMAKE_BINARY_DIR}/_deps/libunwind-build"
-                              CACHE STRING "")
-
-file(WRITE "${workdir}/CMakeLists.txt" "\
-cmake_minimum_required(VERSION ${CMAKE_VERSION})
-project(libunwind-populate NONE)
-include(ExternalProject)
-ExternalProject_Add(libunwind
-  URL               \"${SAPI_LIBUNWIND_URL}\"
-  URL_HASH          \"${SAPI_LIBUNWIND_URL_HASH}\"
-  SOURCE_DIR        \"${SAPI_LIBUNWIND_SOURCE_DIR}\"
-  CONFIGURE_COMMAND ./configure
-                    --disable-dependency-tracking
-                    --disable-documentation
-                    --disable-minidebuginfo
-                    --disable-shared
-                    --enable-ptrace
-                    ${SAPI_THIRD_PARTY_CONFIGUREOPTS}
-  BUILD_COMMAND     \"\"
-  INSTALL_COMMAND   \"\"
-  TEST_COMMAND      \"\"
-  BUILD_IN_SOURCE TRUE
+FetchContent_Declare(libunwind
+  URL https://github.com/libunwind/libunwind/releases/download/v1.6.2/libunwind-1.6.2.tar.gz
+  URL_HASH SHA256=4a6aec666991fb45d0889c44aede8ad6eb108071c3554fcdff671f9c94794976
 )
-")
-
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "CMake step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "Build step for ${PROJECT_NAME} failed: ${error}")
+FetchContent_GetProperties(libunwind)
+if(NOT libunwind_POPULATED)
+  FetchContent_Populate(libunwind)
+  set(libunwind_STATUS_FILE "${libunwind_SOURCE_DIR}/config.status")
+  if(EXISTS "${libunwind_STATUS_FILE}")
+    file(SHA256 "${libunwind_STATUS_FILE}" _sapi_CONFIG_STATUS)
+  endif()
+  if(NOT _sapi_CONFIG_STATUS STREQUAL "${libunwind_CONFIG_STATUS}")
+    message("-- Running ./configure for libunwind...")
+    execute_process(
+      COMMAND ./configure --disable-dependency-tracking
+                          --disable-minidebuginfo
+                          --disable-shared
+                          --enable-ptrace
+                          --quiet
+      WORKING_DIRECTORY "${libunwind_SOURCE_DIR}"
+      RESULT_VARIABLE _sapi_libunwind_config_result
+    )
+    if(NOT _sapi_libunwind_config_result EQUAL "0")
+      message(FATAL_ERROR "Configuration of libunwind dependency failed")
+    endif()
+    file(SHA256 "${libunwind_SOURCE_DIR}/config.status" _sapi_CONFIG_STATUS)
+    set(libunwind_CONFIG_STATUS "${_sapi_CONFIG_STATUS}" CACHE INTERNAL "")
+  endif()
 endif()
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
   set(_unwind_cpu "x86_64")
   list(APPEND _unwind_platform_srcs
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/Gcreate_addr_space.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/Gglobal.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/Ginit.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/Gos-linux.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/Gregs.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/Gresume.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/Gstash_frame.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/Gstep.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/is_fpreg.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/setcontext.S
+    ${libunwind_SOURCE_DIR}/src/x86_64/Gcreate_addr_space.c
+    ${libunwind_SOURCE_DIR}/src/x86_64/Gglobal.c
+    ${libunwind_SOURCE_DIR}/src/x86_64/Ginit.c
+    ${libunwind_SOURCE_DIR}/src/x86_64/Gos-linux.c
+    ${libunwind_SOURCE_DIR}/src/x86_64/Gregs.c
+    ${libunwind_SOURCE_DIR}/src/x86_64/Gresume.c
+    ${libunwind_SOURCE_DIR}/src/x86_64/Gstash_frame.c
+    ${libunwind_SOURCE_DIR}/src/x86_64/Gstep.c
+    ${libunwind_SOURCE_DIR}/src/x86_64/is_fpreg.c
+    ${libunwind_SOURCE_DIR}/src/x86_64/setcontext.S
   )
   list(APPEND _unwind_ptrace_srcs
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/Ginit_remote.c
+    ${libunwind_SOURCE_DIR}/src/x86_64/Ginit_remote.c
   )
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64")
   set(_unwind_cpu "ppc64")
   list(APPEND _unwind_platform_srcs
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ppc/Gis_signal_frame.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ppc64/Gcreate_addr_space.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ppc64/Gglobal.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ppc64/Ginit.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ppc64/Gregs.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ppc64/Gresume.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ppc64/Gstep.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ppc64/get_func_addr.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ppc64/is_fpreg.c
+    ${libunwind_SOURCE_DIR}/src/ppc/Gis_signal_frame.c
+    ${libunwind_SOURCE_DIR}/src/ppc64/Gcreate_addr_space.c
+    ${libunwind_SOURCE_DIR}/src/ppc64/Gglobal.c
+    ${libunwind_SOURCE_DIR}/src/ppc64/Ginit.c
+    ${libunwind_SOURCE_DIR}/src/ppc64/Gregs.c
+    ${libunwind_SOURCE_DIR}/src/ppc64/Gresume.c
+    ${libunwind_SOURCE_DIR}/src/ppc64/Gstep.c
+    ${libunwind_SOURCE_DIR}/src/ppc64/get_func_addr.c
+    ${libunwind_SOURCE_DIR}/src/ppc64/is_fpreg.c
   )
   list(APPEND _unwind_ptrace_srcs
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ppc/Ginit_remote.c
+    ${libunwind_SOURCE_DIR}/src/ppc/Ginit_remote.c
   )
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
   set(_unwind_cpu "aarch64")
   list(APPEND _unwind_platform_srcs
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/aarch64/Gcreate_addr_space.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/aarch64/Gglobal.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/aarch64/Ginit.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/aarch64/Gis_signal_frame.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/aarch64/Gregs.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/aarch64/Gresume.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/aarch64/Gstash_frame.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/aarch64/Gstep.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/aarch64/is_fpreg.c
+    ${libunwind_SOURCE_DIR}/src/aarch64/Gcreate_addr_space.c
+    ${libunwind_SOURCE_DIR}/src/aarch64/Gglobal.c
+    ${libunwind_SOURCE_DIR}/src/aarch64/Ginit.c
+    ${libunwind_SOURCE_DIR}/src/aarch64/Gis_signal_frame.c
+    ${libunwind_SOURCE_DIR}/src/aarch64/Gregs.c
+    ${libunwind_SOURCE_DIR}/src/aarch64/Gresume.c
+    ${libunwind_SOURCE_DIR}/src/aarch64/Gstash_frame.c
+    ${libunwind_SOURCE_DIR}/src/aarch64/Gstep.c
+    ${libunwind_SOURCE_DIR}/src/aarch64/is_fpreg.c
   )
   list(APPEND _unwind_ptrace_srcs
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/aarch64/Ginit_remote.c
+    ${libunwind_SOURCE_DIR}/src/aarch64/Ginit_remote.c
   )
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
   set(_unwind_cpu "arm")
   list(APPEND _unwind_platform_srcs
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/arm/Gcreate_addr_space.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/arm/Gex_tables.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/arm/Gglobal.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/arm/Ginit.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/arm/Gis_signal_frame.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/arm/Gregs.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/arm/Gresume.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/arm/Gstash_frame.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/arm/Gstep.c
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/arm/is_fpreg.c
+    ${libunwind_SOURCE_DIR}/src/arm/Gcreate_addr_space.c
+    ${libunwind_SOURCE_DIR}/src/arm/Gex_tables.c
+    ${libunwind_SOURCE_DIR}/src/arm/Gglobal.c
+    ${libunwind_SOURCE_DIR}/src/arm/Ginit.c
+    ${libunwind_SOURCE_DIR}/src/arm/Gis_signal_frame.c
+    ${libunwind_SOURCE_DIR}/src/arm/Gregs.c
+    ${libunwind_SOURCE_DIR}/src/arm/Gresume.c
+    ${libunwind_SOURCE_DIR}/src/arm/Gstash_frame.c
+    ${libunwind_SOURCE_DIR}/src/arm/Gstep.c
+    ${libunwind_SOURCE_DIR}/src/arm/is_fpreg.c
   )
   list(APPEND _unwind_ptrace_srcs
-    ${SAPI_LIBUNWIND_SOURCE_DIR}/src/arm/Ginit_remote.c
+    ${libunwind_SOURCE_DIR}/src/arm/Ginit_remote.c
   )
 endif()
 
 add_library(unwind_ptrace_wrapped STATIC
   # internal_headers
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/compiler.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/config.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/dwarf.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/dwarf-eh.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/dwarf_i.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/libunwind.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/libunwind-common.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/libunwind-coredump.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/libunwind-dynamic.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/libunwind-ptrace.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/libunwind-x86_64.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/libunwind_i.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/mempool.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/remote.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/tdep-x86_64/dwarf-config.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/tdep-x86_64/libunwind_i.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/tdep/dwarf-config.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/tdep/libunwind_i.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/unwind.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/elf32.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/elf64.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/elfxx.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/os-linux.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/init.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/offsets.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/ucontext_i.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/x86_64/unwind_i.h
+  ${libunwind_SOURCE_DIR}/include/compiler.h
+  ${libunwind_SOURCE_DIR}/include/config.h
+  ${libunwind_SOURCE_DIR}/include/dwarf.h
+  ${libunwind_SOURCE_DIR}/include/dwarf-eh.h
+  ${libunwind_SOURCE_DIR}/include/dwarf_i.h
+  ${libunwind_SOURCE_DIR}/include/libunwind.h
+  ${libunwind_SOURCE_DIR}/include/libunwind-common.h
+  ${libunwind_SOURCE_DIR}/include/libunwind-coredump.h
+  ${libunwind_SOURCE_DIR}/include/libunwind-dynamic.h
+  ${libunwind_SOURCE_DIR}/include/libunwind-ptrace.h
+  ${libunwind_SOURCE_DIR}/include/libunwind-x86_64.h
+  ${libunwind_SOURCE_DIR}/include/libunwind_i.h
+  ${libunwind_SOURCE_DIR}/include/mempool.h
+  ${libunwind_SOURCE_DIR}/include/remote.h
+  ${libunwind_SOURCE_DIR}/include/tdep-x86_64/dwarf-config.h
+  ${libunwind_SOURCE_DIR}/include/tdep-x86_64/libunwind_i.h
+  ${libunwind_SOURCE_DIR}/include/tdep/dwarf-config.h
+  ${libunwind_SOURCE_DIR}/include/tdep/libunwind_i.h
+  ${libunwind_SOURCE_DIR}/include/unwind.h
+  ${libunwind_SOURCE_DIR}/src/elf32.h
+  ${libunwind_SOURCE_DIR}/src/elf64.h
+  ${libunwind_SOURCE_DIR}/src/elfxx.h
+  ${libunwind_SOURCE_DIR}/src/os-linux.h
+  ${libunwind_SOURCE_DIR}/src/x86_64/init.h
+  ${libunwind_SOURCE_DIR}/src/x86_64/offsets.h
+  ${libunwind_SOURCE_DIR}/src/x86_64/ucontext_i.h
+  ${libunwind_SOURCE_DIR}/src/x86_64/unwind_i.h
   # included_sources
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/elf64.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/elfxx.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/elfxx.c
+  ${libunwind_SOURCE_DIR}/src/elf64.h
+  ${libunwind_SOURCE_DIR}/src/elfxx.h
+  ${libunwind_SOURCE_DIR}/src/elfxx.c
   # sources_common
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/dwarf/Gexpr.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/dwarf/Gfde.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/dwarf/Gfind_proc_info-lsb.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/dwarf/Gfind_unwind_table.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/dwarf/Gparser.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/dwarf/Gpe.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/dwarf/global.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/mi/Gdestroy_addr_space.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/mi/Gdyn-extract.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/mi/Gfind_dynamic_proc_info.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/mi/Gget_accessors.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/mi/Gget_proc_name.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/mi/Gget_reg.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/mi/Gput_dynamic_unwind_info.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/mi/flush_cache.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/mi/init.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/mi/mempool.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/os-linux.c
+  ${libunwind_SOURCE_DIR}/src/dwarf/Gexpr.c
+  ${libunwind_SOURCE_DIR}/src/dwarf/Gfde.c
+  ${libunwind_SOURCE_DIR}/src/dwarf/Gfind_proc_info-lsb.c
+  ${libunwind_SOURCE_DIR}/src/dwarf/Gfind_unwind_table.c
+  ${libunwind_SOURCE_DIR}/src/dwarf/Gparser.c
+  ${libunwind_SOURCE_DIR}/src/dwarf/Gpe.c
+  ${libunwind_SOURCE_DIR}/src/dwarf/global.c
+  ${libunwind_SOURCE_DIR}/src/mi/Gdestroy_addr_space.c
+  ${libunwind_SOURCE_DIR}/src/mi/Gdyn-extract.c
+  ${libunwind_SOURCE_DIR}/src/mi/Gfind_dynamic_proc_info.c
+  ${libunwind_SOURCE_DIR}/src/mi/Gget_accessors.c
+  ${libunwind_SOURCE_DIR}/src/mi/Gget_proc_name.c
+  ${libunwind_SOURCE_DIR}/src/mi/Gget_reg.c
+  ${libunwind_SOURCE_DIR}/src/mi/Gput_dynamic_unwind_info.c
+  ${libunwind_SOURCE_DIR}/src/mi/flush_cache.c
+  ${libunwind_SOURCE_DIR}/src/mi/init.c
+  ${libunwind_SOURCE_DIR}/src/mi/mempool.c
+  ${libunwind_SOURCE_DIR}/src/os-linux.c
   ${_unwind_platform_srcs}
   # srcs
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/mi/Gdyn-remote.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_access_fpreg.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_access_mem.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_access_reg.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_accessors.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_create.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_destroy.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_elf.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_find_proc_info.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_get_dyn_info_list_addr.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_get_proc_name.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_internal.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_put_unwind_info.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_reg_offset.c
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src/ptrace/_UPT_resume.c
+  ${libunwind_SOURCE_DIR}/src/mi/Gdyn-remote.c
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_access_fpreg.c
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_access_mem.c
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_access_reg.c
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_accessors.c
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_create.c
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_destroy.c
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_elf.c
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_find_proc_info.c
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_get_dyn_info_list_addr.c
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_get_proc_name.c
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_internal.h
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_put_unwind_info.c
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_reg_offset.c
+  ${libunwind_SOURCE_DIR}/src/ptrace/_UPT_resume.c
   # hdrs
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/config.h
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/libunwind.h
+  ${libunwind_SOURCE_DIR}/include/config.h
+  ${libunwind_SOURCE_DIR}/include/libunwind.h
   # source_ptrace
   ${_unwind_ptrace_srcs}
 )
 add_library(unwind::unwind_ptrace_wrapped ALIAS unwind_ptrace_wrapped)
 target_include_directories(unwind_ptrace_wrapped PUBLIC
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/tdep
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/include/tdep-${_unwind_cpu}
-  ${SAPI_LIBUNWIND_SOURCE_DIR}/src
+  ${libunwind_SOURCE_DIR}/include
+  ${libunwind_SOURCE_DIR}/include/tdep
+  ${libunwind_SOURCE_DIR}/include/tdep-${_unwind_cpu}
+  ${libunwind_SOURCE_DIR}/src
 )
 target_compile_options(unwind_ptrace_wrapped PRIVATE
   -fno-common

--- a/cmake/zlib.cmake
+++ b/cmake/zlib.cmake
@@ -12,87 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(workdir "${CMAKE_BINARY_DIR}/_deps/zlib-populate")
-
-set(SAPI_ZLIB_URL https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz
-                  CACHE STRING "")
-set(SAPI_ZLIB_URL_HASH
-  SHA256=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
-  CACHE STRING "") # 2020-04-23
-set(SAPI_ZLIB_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/zlib-src" CACHE STRING "")
-set(SAPI_ZLIB_BINARY_DIR "${CMAKE_BINARY_DIR}/_deps/zlib-build" CACHE STRING "")
-
-file(WRITE "${workdir}/CMakeLists.txt" "\
-cmake_minimum_required(VERSION ${CMAKE_VERSION})
-project(zlib-populate NONE)
-include(ExternalProject)
-ExternalProject_Add(zlib
-  URL           \"${SAPI_ZLIB_URL}\"
-  URL_HASH      \"${SAPI_ZLIB_URL_HASH}\"
-  SOURCE_DIR    \"${SAPI_ZLIB_SOURCE_DIR}\"
-  BINARY_DIR    \"${SAPI_ZLIB_BINARY_DIR}\"
+FetchContent_Declare(zlib
+  URL      https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz
+  URL_HASH SHA256=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
   PATCH_COMMAND patch -p1
-                < \"${SAPI_SOURCE_DIR}/sandboxed_api/bazel/external/zlib.patch\"
-  CONFIGURE_COMMAND \"\"
-  BUILD_COMMAND     \"\"
-  INSTALL_COMMAND   \"\"
-  TEST_COMMAND      \"\"
+                < "${SAPI_SOURCE_DIR}/sandboxed_api/bazel/external/zlib.patch"
 )
-")
-
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "CMake step for ${PROJECT_NAME} failed: ${error}")
-endif()
-
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                RESULT_VARIABLE error
-                WORKING_DIRECTORY "${workdir}")
-if(error)
-  message(FATAL_ERROR "Build step for ${PROJECT_NAME} failed: ${error}")
-endif()
+FetchContent_MakeAvailable(zlib)
 
 set(ZLIB_FOUND TRUE)
-set(ZLIB_INCLUDE_DIRS ${SAPI_ZLIB_SOURCE_DIR})
+set(ZLIB_INCLUDE_DIRS ${zlib_SOURCE_DIR})
 
-add_library(z STATIC
-  ${SAPI_ZLIB_SOURCE_DIR}/adler32.c
-  ${SAPI_ZLIB_SOURCE_DIR}/compress.c
-  ${SAPI_ZLIB_SOURCE_DIR}/crc32.c
-  ${SAPI_ZLIB_SOURCE_DIR}/crc32.h
-  ${SAPI_ZLIB_SOURCE_DIR}/deflate.c
-  ${SAPI_ZLIB_SOURCE_DIR}/deflate.h
-  ${SAPI_ZLIB_SOURCE_DIR}/gzclose.c
-  ${SAPI_ZLIB_SOURCE_DIR}/gzguts.h
-  ${SAPI_ZLIB_SOURCE_DIR}/gzlib.c
-  ${SAPI_ZLIB_SOURCE_DIR}/gzread.c
-  ${SAPI_ZLIB_SOURCE_DIR}/gzwrite.c
-  ${SAPI_ZLIB_SOURCE_DIR}/infback.c
-  ${SAPI_ZLIB_SOURCE_DIR}/inffast.c
-  ${SAPI_ZLIB_SOURCE_DIR}/inffast.h
-  ${SAPI_ZLIB_SOURCE_DIR}/inffixed.h
-  ${SAPI_ZLIB_SOURCE_DIR}/inflate.c
-  ${SAPI_ZLIB_SOURCE_DIR}/inflate.h
-  ${SAPI_ZLIB_SOURCE_DIR}/inftrees.c
-  ${SAPI_ZLIB_SOURCE_DIR}/inftrees.h
-  ${SAPI_ZLIB_SOURCE_DIR}/trees.c
-  ${SAPI_ZLIB_SOURCE_DIR}/trees.h
-  ${SAPI_ZLIB_SOURCE_DIR}/uncompr.c
-  ${SAPI_ZLIB_SOURCE_DIR}/zconf.h
-  ${SAPI_ZLIB_SOURCE_DIR}/zlib.h
-  ${SAPI_ZLIB_SOURCE_DIR}/zutil.c
-  ${SAPI_ZLIB_SOURCE_DIR}/zutil.h
-)
-add_library(ZLIB::ZLIB ALIAS z)
-target_include_directories(z PUBLIC
-  ${SAPI_ZLIB_SOURCE_DIR}
-)
-target_compile_options(z PRIVATE
-  -w
-  -Dverbose=-1
-)
-target_link_libraries(z PRIVATE
-  sapi::base
+add_library(ZLIB::ZLIB ALIAS zlibstatic)
+target_include_directories(zlibstatic PUBLIC
+  ${ZLIB_INCLUDE_DIRS}
 )


### PR DESCRIPTION
This updates the mininum required version of CMake to 3.13, which is
present in Debian Buster.

At the same time, move all of our dependency handling to use
`FetchContent_Declare()`, `FetchContent_Populate()` and
`FetchContent_MakeAvailable()`. Since the latter was ony introduced in
3.14, provide a simple "polyfill" implementation for that.

As an added benefit, the configure step for libffi and libunwind will
now not be re-run every time the `CMakeLists.txt` changes.

Other changes:
- Explicitly spell out that we're testing up to 3.22 in
  `cmake_minimum_version()`
- Rename `check_target()` to `sapi_check_target()` to avoid conflicts
  with Abseil.