### PR TITLE
Jsonnet: Use `FetchContent` instead of git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "oss-internship-2020/sapi_lodepng/lodepng"]
 	path = oss-internship-2020/lodepng/lodepng
 	url = https://github.com/lvandeve/lodepng
-[submodule "oss-internship-2020/jsonnet/jsonnet"]
-	path = oss-internship-2020/jsonnet/jsonnet
-	url = https://github.com/google/jsonnet.git
 [submodule "oss-internship-2020/openjpeg/openjpeg"]
 	path = oss-internship-2020/openjpeg/openjpeg
 	url = https://github.com/uclouvain/openjpeg.git

--- a/oss-internship-2020/jsonnet/CMakeLists.txt
+++ b/oss-internship-2020/jsonnet/CMakeLists.txt
@@ -12,24 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.10)
-
+cmake_minimum_required(VERSION 3.13..3.22)
 project(jsonnet-sapi C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-add_subdirectory(jsonnet)
-
-add_subdirectory(examples)
-
 set(SAPI_ROOT "../.." CACHE PATH "Path to the Sandboxed API source tree")
-set(SAPI_ENABLE_EXAMPLES OFF CACHE BOOL "")
-set(SAPI_ENABLE_TESTS OFF CACHE BOOL "")
 
 add_subdirectory("${SAPI_ROOT}"
                  "${CMAKE_BINARY_DIR}/sandboxed-api-build"
                  EXCLUDE_FROM_ALL)
+
+FetchContent_Declare(jsonnet
+  GIT_REPOSITORY https://github.com/google/jsonnet.git
+  GIT_TAG        v0.18.0 # 2021-12-21
+)
+set(BUILD_TESTS OFF)
+FetchContent_MakeAvailable(jsonnet)
+create_directory_symlink("${jsonnet_SOURCE_DIR}"
+                         "${PROJECT_BINARY_DIR}/jsonnet")
+
+add_subdirectory(examples)
 
 add_sapi_library(jsonnet_sapi
   FUNCTIONS c_free_input
@@ -56,4 +60,9 @@ target_include_directories(jsonnet_sapi INTERFACE
 
 target_link_libraries(jsonnet_sapi PUBLIC jsonnet_helper)
 
-add_subdirectory(tests)
+if(SAPI_ENABLE_TESTS)
+  include(GoogleTest)
+  enable_testing()
+
+  add_subdirectory(tests)
+endif()

--- a/oss-internship-2020/jsonnet/README.md
+++ b/oss-internship-2020/jsonnet/README.md
@@ -1,6 +1,6 @@
 # Jsonnet Sandboxed API
 
-This library provides sandboxed version of the
+This library provides a sandboxed version of the
 [Jsonnet](https://github.com/google/jsonnet) library.
 
 ## Examples
@@ -22,18 +22,12 @@ canonical form.
 
 ## Build
 
-To build these examples, after cloning the whole Sandbox API project, you also
-need to run
+To build these examples, after cloning the whole Sandbox API project, this
+in the `sandboxed-api/oss-internship-2020/jsonnet`:
 
 ```
-git submodule update --init --recursive
-```
-anywhere in the project tree in order to clone the `jsonnet` submodule.
-Then in the `sandboxed-api/oss-internship-2020/jsonnet` run
-
-```
-mkdir build && cd build
-cmake -G Ninja
+mkdir -p build && cd build
+cmake .. -G Ninja -Wno-dev -DSAPI_ENABLE_TESTS=ON
 ninja
 ```
 
@@ -79,6 +73,5 @@ A few tests prepared with a use of
 the `tests/` directory. To run them type:
 
 ```
-cd tests
-./tests
+ctest ./tests
 ```

--- a/oss-internship-2020/jsonnet/examples/CMakeLists.txt
+++ b/oss-internship-2020/jsonnet/examples/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/gen_files")
-file(COPY "${PROJECT_SOURCE_DIR}/jsonnet/cmd/jsonnet.cpp" DESTINATION "${PROJECT_BINARY_DIR}/gen_files/")
+file(COPY "${jsonnet_SOURCE_DIR}/cmd/jsonnet.cpp" DESTINATION "${PROJECT_BINARY_DIR}/gen_files/")
 file(COPY "${PROJECT_SOURCE_DIR}/jsonnet.patch" DESTINATION "${PROJECT_BINARY_DIR}/gen_files/")
 
 add_custom_command(
@@ -22,34 +22,35 @@ add_custom_command(
   COMMAND mv ${PROJECT_BINARY_DIR}/gen_files/jsonnet.cpp ${PROJECT_BINARY_DIR}/gen_files/write_helper.cc
 )
 
-list(APPEND JSONNET_SAPI_HEADERS
+list(APPEND JSONNET_SAPI_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}
   ${PROJECT_SOURCE_DIR}/headers
+  ${PROJECT_BINARY_DIR}
   ${PROJECT_BINARY_DIR}/gen_files
 )
 
 add_library(jsonnet_helper STATIC
   ${PROJECT_SOURCE_DIR}/jsonnet_helper.cc
   ${PROJECT_SOURCE_DIR}/jsonnet_helper.h
-  ${PROJECT_SOURCE_DIR}/jsonnet/cmd/utils.h
-  ${PROJECT_SOURCE_DIR}/jsonnet/cmd/utils.cpp
+  ${jsonnet_SOURCE_DIR}/cmd/utils.h
+  ${jsonnet_SOURCE_DIR}/cmd/utils.cpp
   ${PROJECT_BINARY_DIR}/gen_files/write_helper.cc
 )
 
 target_include_directories(jsonnet_helper PUBLIC
-  ${JSONNET_SAPI_HEADERS}
+  ${JSONNET_SAPI_INCLUDE_DIRS}
 )
 
 target_link_libraries(jsonnet_helper
   libjsonnet_for_binaries
 )
 
-foreach(exe base multiple_files yaml_stream formatter)
-  add_executable(jsonnet_${exe}_sandboxed
-    jsonnet_${exe}_example.cc
+foreach(target IN ITEMS base multiple_files yaml_stream formatter)
+  add_executable(jsonnet_${target}_sandboxed
+    jsonnet_${target}_example.cc
   )
 
-  target_link_libraries(jsonnet_${exe}_sandboxed PRIVATE
+  target_link_libraries(jsonnet_${target}_sandboxed PRIVATE
     libjsonnet
     jsonnet_helper
     jsonnet_sapi
@@ -58,8 +59,8 @@ foreach(exe base multiple_files yaml_stream formatter)
     sapi::sapi
   )
 
-  target_include_directories(jsonnet_${exe}_sandboxed PUBLIC
-    ${JSONNET_SAPI_HEADERS}
+  target_include_directories(jsonnet_${target}_sandboxed PUBLIC
+    ${JSONNET_SAPI_INCLUDE_DIRS}
   )
 endforeach()
 

--- a/oss-internship-2020/jsonnet/tests/CMakeLists.txt
+++ b/oss-internship-2020/jsonnet/tests/CMakeLists.txt
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(GoogleTest)
-
 # We need to prepare convenient directories so the tests will be able to access them
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/tests/tests_input)
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/tests/tests_output)


### PR DESCRIPTION
- Update instructions
- Tested with CMake 3.13