### PR TITLE
ZStandard: Introduce fd wrapper

### DIFF
--- a/contrib/zstd/CMakeLists.txt
+++ b/contrib/zstd/CMakeLists.txt
@@ -34,6 +34,8 @@ FetchContent_Declare(libzstd
 FetchContent_MakeAvailable(libzstd)
 
 set(libzstd_INCLUDE_DIR "${libzstd_SOURCE_DIR}/lib")
+add_subdirectory(wrapper)
+
 add_sapi_library(
   sapi_zstd
 
@@ -70,10 +72,16 @@ add_sapi_library(
 
     ZSTD_getFrameContentSize
 
+    ZSTD_compress_fd
+    ZSTD_compressStream_fd
+
+    ZSTD_decompress_fd
+    ZSTD_decompressStream_fd
   INPUTS
     ${libzstd_INCLUDE_DIR}/zstd.h
+    wrapper/wrapper_zstd.h
 
-  LIBRARY libzstd_static
+  LIBRARY wrapper_zstd
   LIBRARY_NAME Zstd
   NAMESPACE ""
 )

--- a/contrib/zstd/example/main.cc
+++ b/contrib/zstd/example/main.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fcntl.h>
 #include <unistd.h>
 
 #include <cstdlib>
@@ -25,9 +26,57 @@
 #include "contrib/zstd/sandboxed.h"
 #include "contrib/zstd/utils/utils_zstd.h"
 
+ABSL_FLAG(bool, stream, false, "stream data to sandbox");
 ABSL_FLAG(bool, decompress, false, "decompress");
 ABSL_FLAG(bool, memory_mode, false, "in memory operations");
 ABSL_FLAG(uint32_t, level, 0, "compression level");
+
+absl::Status Stream(ZstdApi& api, std::string infile_s, std::string outfile_s) {
+  std::ifstream infile(infile_s, std::ios::binary);
+  if (!infile.is_open()) {
+    return absl::UnavailableError(absl::StrCat("Unable to open ", infile_s));
+  }
+  std::ofstream outfile(outfile_s, std::ios::binary);
+  if (!outfile.is_open()) {
+    return absl::UnavailableError(absl::StrCat("Unable to open ", outfile_s));
+  }
+
+  if (absl::GetFlag(FLAGS_memory_mode) && absl::GetFlag(FLAGS_decompress)) {
+    return DecompressInMemory(api, infile, outfile);
+  }
+  if (absl::GetFlag(FLAGS_memory_mode) && !absl::GetFlag(FLAGS_decompress)) {
+    return CompressInMemory(api, infile, outfile, absl::GetFlag(FLAGS_level));
+  }
+  if (!absl::GetFlag(FLAGS_memory_mode) && absl::GetFlag(FLAGS_decompress)) {
+    return DecompressStream(api, infile, outfile);
+  }
+
+  return CompressStream(api, infile, outfile, absl::GetFlag(FLAGS_level));
+}
+
+absl::Status FileDescriptor(ZstdApi& api, std::string infile_s,
+                            std::string outfile_s) {
+  sapi::v::Fd infd(open(infile_s.c_str(), O_RDONLY));
+  if (infd.GetValue() < 0) {
+    return absl::UnavailableError(absl::StrCat("Unable to open ", infile_s));
+  }
+  sapi::v::Fd outfd(open(outfile_s.c_str(), O_WRONLY | O_CREAT));
+  if (outfd.GetValue() < 0) {
+    return absl::UnavailableError(absl::StrCat("Unable to open ", outfile_s));
+  }
+
+  if (absl::GetFlag(FLAGS_memory_mode) && absl::GetFlag(FLAGS_decompress)) {
+    return DecompressInMemoryFD(api, infd, outfd);
+  }
+  if (absl::GetFlag(FLAGS_memory_mode) && !absl::GetFlag(FLAGS_decompress)) {
+    return CompressInMemoryFD(api, infd, outfd, absl::GetFlag(FLAGS_level));
+  }
+  if (!absl::GetFlag(FLAGS_memory_mode) && absl::GetFlag(FLAGS_decompress)) {
+    return DecompressStreamFD(api, infd, outfd);
+  }
+
+  return CompressStreamFD(api, infd, outfd, absl::GetFlag(FLAGS_level));
+}
 
 int main(int argc, char* argv[]) {
   std::string prog_name(argv[0]);
@@ -36,17 +85,6 @@ int main(int argc, char* argv[]) {
 
   if (args.size() != 3) {
     std::cerr << "Usage:\n  " << prog_name << " INPUT OUTPUT\n";
-    return EXIT_FAILURE;
-  }
-
-  std::ifstream infile(args[1], std::ios::binary);
-  if (!infile.is_open()) {
-    std::cerr << "Unable to open " << args[1] << std::endl;
-    return EXIT_FAILURE;
-  }
-  std::ofstream outfile(args[2], std::ios::binary);
-  if (!outfile.is_open()) {
-    std::cerr << "Unable to open " << args[2] << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -59,16 +97,10 @@ int main(int argc, char* argv[]) {
   ZstdApi api(&sandbox);
 
   absl::Status status;
-  if (absl::GetFlag(FLAGS_memory_mode) && absl::GetFlag(FLAGS_decompress)) {
-    status = DecompressInMemory(api, infile, outfile);
-  } else if (absl::GetFlag(FLAGS_memory_mode) &&
-             !absl::GetFlag(FLAGS_decompress)) {
-    status = CompressInMemory(api, infile, outfile, absl::GetFlag(FLAGS_level));
-  } else if (!absl::GetFlag(FLAGS_memory_mode) &&
-             absl::GetFlag(FLAGS_decompress)) {
-    status = DecompressStream(api, infile, outfile);
+  if (absl::GetFlag(FLAGS_stream)) {
+    status = Stream(api, argv[1], argv[2]);
   } else {
-    status = CompressStream(api, infile, outfile, absl::GetFlag(FLAGS_level));
+    status = FileDescriptor(api, argv[1], argv[2]);
   }
 
   if (!status.ok()) {

--- a/contrib/zstd/sandboxed.h
+++ b/contrib/zstd/sandboxed.h
@@ -27,10 +27,14 @@ class ZstdSapiSandbox : public ZstdSandbox {
   std::unique_ptr<sandbox2::Policy> ModifyPolicy(
       sandbox2::PolicyBuilder*) override {
     return sandbox2::PolicyBuilder()
+        .AllowDynamicStartup()
         .AllowRead()
         .AllowWrite()
         .AllowSystemMalloc()
         .AllowExit()
+        .AllowSyscalls({
+          __NR_recvmsg
+        })
         .BuildOrDie();
   }
 };

--- a/contrib/zstd/test/zstd_test.cc
+++ b/contrib/zstd/test/zstd_test.cc
@@ -18,10 +18,10 @@
 #include <fstream>
 #include <string>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "contrib/zstd/sandboxed.h"
 #include "contrib/zstd/utils/utils_zstd.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "sandboxed_api/util/path.h"
 #include "sandboxed_api/util/status_matchers.h"
 #include "sandboxed_api/util/temp_file.h"

--- a/contrib/zstd/test/zstd_test.cc
+++ b/contrib/zstd/test/zstd_test.cc
@@ -104,11 +104,10 @@ TEST(SandboxTest, CheckCompressInMemory) {
 
   std::string infile_s = GetTestFilePath("text");
 
-  absl::StatusOr<std::string> path =
-      sapi::CreateNamedTempFileAndClose("out.zstd");
-  ASSERT_THAT(path, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path,
+                            sapi::CreateNamedTempFileAndClose("out.zstd"));
   std::string outfile_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path);
 
   std::ifstream infile(infile_s, std::ios::binary);
   ASSERT_TRUE(infile.is_open());
@@ -129,10 +128,10 @@ TEST(SandboxTest, CheckDecompressInMemory) {
 
   std::string infile_s = GetTestFilePath("text.blob.zstd");
 
-  absl::StatusOr<std::string> path = sapi::CreateNamedTempFileAndClose("out");
-  ASSERT_THAT(path, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path,
+                            sapi::CreateNamedTempFileAndClose("out"));
   std::string outfile_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path);
 
   std::ifstream infile(infile_s, std::ios::binary);
   ASSERT_TRUE(infile.is_open());
@@ -156,16 +155,15 @@ TEST(SandboxTest, CheckCompressAndDecompressInMemory) {
 
   std::string infile_s = GetTestFilePath("text");
 
-  absl::StatusOr<std::string> path_middle =
-      sapi::CreateNamedTempFileAndClose("middle.zstd");
-  ASSERT_THAT(path_middle, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path_middle,
+                            sapi::CreateNamedTempFileAndClose("middle.zstd"));
   std::string middle_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path_middle);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path_middle);
 
-  absl::StatusOr<std::string> path = sapi::CreateNamedTempFileAndClose("out");
-  ASSERT_THAT(path, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path,
+                            sapi::CreateNamedTempFileAndClose("out"));
   std::string outfile_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path);
 
   std::ifstream infile(infile_s, std::ios::binary);
   ASSERT_TRUE(infile.is_open());
@@ -196,12 +194,10 @@ TEST(SandboxTest, CheckCompressStream) {
   ZstdApi api = ZstdApi(&sandbox);
 
   std::string infile_s = GetTestFilePath("text");
-
-  absl::StatusOr<std::string> path =
-      sapi::CreateNamedTempFileAndClose("out.zstd");
-  ASSERT_THAT(path, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path,
+                            sapi::CreateNamedTempFileAndClose("out.zstd"));
   std::string outfile_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path);
 
   std::ifstream infile(infile_s, std::ios::binary);
   ASSERT_TRUE(infile.is_open());
@@ -223,11 +219,10 @@ TEST(SandboxTest, CheckDecompressStream) {
   ZstdApi api = ZstdApi(&sandbox);
 
   std::string infile_s = GetTestFilePath("text.stream.zstd");
-
-  absl::StatusOr<std::string> path = sapi::CreateNamedTempFileAndClose("out");
-  ASSERT_THAT(path, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path,
+                            sapi::CreateNamedTempFileAndClose("out"));
   std::string outfile_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path);
 
   std::ifstream infile(infile_s, std::ios::binary);
   ASSERT_TRUE(infile.is_open());
@@ -251,16 +246,15 @@ TEST(SandboxTest, CheckCompressAndDecompressStream) {
 
   std::string infile_s = GetTestFilePath("text");
 
-  absl::StatusOr<std::string> path_middle =
-      sapi::CreateNamedTempFileAndClose("middle.zstd");
-  ASSERT_THAT(path_middle, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path_middle,
+                            sapi::CreateNamedTempFileAndClose("middle.zstd"));
   std::string middle_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path_middle);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path_middle);
 
-  absl::StatusOr<std::string> path = sapi::CreateNamedTempFileAndClose("out");
-  ASSERT_THAT(path, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path,
+                            sapi::CreateNamedTempFileAndClose("out"));
   std::string outfile_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path);
 
   std::ifstream infile(infile_s, std::ios::binary);
   ASSERT_TRUE(infile.is_open());
@@ -293,11 +287,10 @@ TEST(SandboxTest, CheckCompressInMemoryFD) {
 
   std::string infile_s = GetTestFilePath("text");
 
-  absl::StatusOr<std::string> path =
-      sapi::CreateNamedTempFileAndClose("out.zstd");
-  ASSERT_THAT(path, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path,
+                            sapi::CreateNamedTempFileAndClose("out.zstd"));
   std::string outfile_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path);
 
   sapi::v::Fd infd(open(infile_s.c_str(), O_RDONLY));
   ASSERT_GE(infd.GetValue(), 0);
@@ -324,10 +317,10 @@ TEST(SandboxTest, CheckDecompressInMemoryFD) {
   sapi::v::Fd infd(open(infile_s.c_str(), O_RDONLY));
   ASSERT_GE(infd.GetValue(), 0);
 
-  absl::StatusOr<std::string> path = sapi::CreateNamedTempFileAndClose("out");
-  ASSERT_THAT(path, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path,
+                            sapi::CreateNamedTempFileAndClose("out"));
   std::string outfile_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path);
   sapi::v::Fd outfd(open(outfile_s.c_str(), O_WRONLY));
   ASSERT_GE(outfd.GetValue(), 0);
 
@@ -354,16 +347,15 @@ TEST(SandboxTest, CheckCompressAndDecompressInMemoryFD) {
 
   std::string infile_s = GetTestFilePath("text");
 
-  absl::StatusOr<std::string> path_middle =
-      sapi::CreateNamedTempFileAndClose("middle.zstd");
-  ASSERT_THAT(path_middle, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path_middle,
+                            sapi::CreateNamedTempFileAndClose("middle.zstd"));
   std::string middle_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path_middle);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path_middle);
 
-  absl::StatusOr<std::string> path = sapi::CreateNamedTempFileAndClose("out");
-  ASSERT_THAT(path, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path,
+                            sapi::CreateNamedTempFileAndClose("out"));
   std::string outfile_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path);
 
   sapi::v::Fd infd(open(infile_s.c_str(), O_RDONLY));
   ASSERT_GE(infd.GetValue(), 0);
@@ -408,11 +400,10 @@ TEST(SandboxTest, CheckCompressStreamFD) {
 
   std::string infile_s = GetTestFilePath("text");
 
-  absl::StatusOr<std::string> path =
-      sapi::CreateNamedTempFileAndClose("out.zstd");
-  ASSERT_THAT(path, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path,
+                            sapi::CreateNamedTempFileAndClose("out.zstd"));
   std::string outfile_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path);
 
   sapi::v::Fd infd(open(infile_s.c_str(), O_RDONLY));
   ASSERT_GE(infd.GetValue(), 0);
@@ -440,10 +431,10 @@ TEST(SandboxTest, CheckDecompressStreamFD) {
 
   std::string infile_s = GetTestFilePath("text.stream.zstd");
 
-  absl::StatusOr<std::string> path = sapi::CreateNamedTempFileAndClose("out");
-  ASSERT_THAT(path, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path,
+                            sapi::CreateNamedTempFileAndClose("out"));
   std::string outfile_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path);
 
   sapi::v::Fd infd(open(infile_s.c_str(), O_RDONLY));
   ASSERT_GE(infd.GetValue(), 0);
@@ -474,16 +465,15 @@ TEST(SandboxTest, CheckCompressAndDecompressStreamFD) {
 
   std::string infile_s = GetTestFilePath("text");
 
-  absl::StatusOr<std::string> path_middle =
-      sapi::CreateNamedTempFileAndClose("middle.zstd");
-  ASSERT_THAT(path_middle, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path_middle,
+                            sapi::CreateNamedTempFileAndClose("middle.zstd"));
   std::string middle_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path_middle);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path_middle);
 
-  absl::StatusOr<std::string> path = sapi::CreateNamedTempFileAndClose("out");
-  ASSERT_THAT(path, IsOk()) << "Could not create temp output file";
+  SAPI_ASSERT_OK_AND_ASSIGN(std::string path,
+                            sapi::CreateNamedTempFileAndClose("out"));
   std::string outfile_s =
-      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), *path);
+      sapi::file::JoinPath(sapi::file_util::fileops::GetCWD(), path);
 
   sapi::v::Fd infd(open(infile_s.c_str(), O_RDONLY));
   ASSERT_GE(infd.GetValue(), 0);

--- a/contrib/zstd/utils/utils_zstd.h
+++ b/contrib/zstd/utils/utils_zstd.h
@@ -24,10 +24,18 @@ absl::Status CompressInMemory(ZstdApi& api, std::ifstream& in_stream,
                               std::ofstream& out_stream, int level);
 absl::Status DecompressInMemory(ZstdApi& api, std::ifstream& in_stream,
                                 std::ofstream& out_stream);
+absl::Status CompressInMemoryFD(ZstdApi& api, sapi::v::Fd& infd,
+                                sapi::v::Fd& outfd, int level);
+absl::Status DecompressInMemoryFD(ZstdApi& api, sapi::v::Fd& infd,
+                                  sapi::v::Fd& outfd);
 
 absl::Status CompressStream(ZstdApi& api, std::ifstream& in_stream,
                             std::ofstream& out_stream, int level);
 absl::Status DecompressStream(ZstdApi& api, std::ifstream& in_stream,
                               std::ofstream& out_stream);
+absl::Status CompressStreamFD(ZstdApi& api, sapi::v::Fd& infd,
+                              sapi::v::Fd& outfd, int level);
+absl::Status DecompressStreamFD(ZstdApi& api, sapi::v::Fd& infd,
+                                sapi::v::Fd& outfd);
 
 #endif  // CONTRIB_ZSTD_UTILS_UTILS_ZSTD_H_

--- a/contrib/zstd/wrapper/CMakeLists.txt
+++ b/contrib/zstd/wrapper/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(
+  wrapper_zstd STATIC
+
+  wrapper_zstd.cc
+)
+
+target_link_libraries(wrapper_zstd PUBLIC
+  libzstd_static
+)
+
+target_include_directories(wrapper_zstd PUBLIC
+  ${libzstd_INCLUDE_DIR}
+)

--- a/contrib/zstd/wrapper/CMakeLists.txt
+++ b/contrib/zstd/wrapper/CMakeLists.txt
@@ -23,5 +23,6 @@ target_link_libraries(wrapper_zstd PUBLIC
 )
 
 target_include_directories(wrapper_zstd PUBLIC
+  ${SAPI_SOURCE_DIR}
   ${libzstd_INCLUDE_DIR}
 )

--- a/contrib/zstd/wrapper/wrapper_zstd.cc
+++ b/contrib/zstd/wrapper/wrapper_zstd.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "wrapper_zstd.h"
+#include "contrib/zstd/wrapper/wrapper_zstd.h"
 
 #include <errno.h>
 #include <fcntl.h>

--- a/contrib/zstd/wrapper/wrapper_zstd.cc
+++ b/contrib/zstd/wrapper/wrapper_zstd.cc
@@ -1,0 +1,184 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "wrapper_zstd.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+#include "zstd.h"
+
+static constexpr size_t kFileMaxSize = 1024 * 1024 * 1024;  // 1GB
+
+off_t FDGetSize(int fd) {
+  off_t size = lseek(fd, 0, SEEK_END);
+  if (size < 0) {
+    return -1;
+  }
+  if (lseek(fd, 0, SEEK_SET) < 0) {
+    return -1;
+  }
+
+  return size;
+}
+
+int ZSTD_compress_fd(int fdin, int fdout, int level) {
+  off_t sizein = FDGetSize(fdin);
+  if (sizein <= 0) {
+    return -1;
+  }
+
+  size_t sizeout = ZSTD_compressBound(sizein);
+
+  auto bufin = std::make_unique<int8_t[]>(sizein);
+  auto bufout = std::make_unique<int8_t[]>(sizeout);
+
+  if (read(fdin, bufin.get(), sizein) != sizein) {
+    return -1;
+  }
+
+  int retsize =
+      ZSTD_compress(bufout.get(), sizeout, bufin.get(), sizein, level);
+  if (ZSTD_isError(retsize)) {
+    return -1;
+  }
+
+  if (write(fdout, bufout.get(), retsize) != retsize) {
+    return -1;
+  }
+
+  return 0;
+}
+
+int ZSTD_compressStream_fd(ZSTD_CCtx* cctx, int fdin, int fdout) {
+  size_t sizein = ZSTD_CStreamInSize();
+  size_t sizeout = ZSTD_CStreamOutSize();
+
+  auto bufin = std::make_unique<int8_t[]>(sizein);
+  auto bufout = std::make_unique<int8_t[]>(sizeout);
+
+  ssize_t size;
+  while ((size = read(fdin, bufin.get(), sizein)) > 0) {
+    ZSTD_inBuffer_s struct_in;
+    struct_in.src = bufin.get();
+    struct_in.pos = 0;
+    struct_in.size = size;
+
+    ZSTD_EndDirective mode = ZSTD_e_continue;
+    if (size < sizein) {
+      mode = ZSTD_e_end;
+    }
+
+    bool isdone = false;
+    while (!isdone) {
+      ZSTD_outBuffer_s struct_out;
+      struct_out.dst = bufout.get();
+      struct_out.pos = 0;
+      struct_out.size = sizeout;
+
+      size_t remaining =
+          ZSTD_compressStream2(cctx, &struct_out, &struct_in, mode);
+      if (ZSTD_isError(remaining)) {
+        return -1;
+      }
+      if (write(fdout, bufout.get(), struct_out.pos) != struct_out.pos) {
+        return -1;
+      }
+
+      if (mode == ZSTD_e_continue) {
+        isdone = (struct_in.pos == size);
+      } else {
+        isdone = (remaining == 0);
+      }
+    }
+  }
+
+  if (size != 0) {
+    return -1;
+  }
+
+  return 0;
+}
+
+int ZSTD_decompress_fd(int fdin, int fdout) {
+  off_t sizein = FDGetSize(fdin);
+  if (sizein <= 0) {
+    return -1;
+  }
+  auto bufin = std::make_unique<int8_t[]>(sizein);
+  if (read(fdin, bufin.get(), sizein) != sizein) {
+    return -1;
+  }
+
+  size_t sizeout = ZSTD_getFrameContentSize(bufin.get(), sizein);
+  if (ZSTD_isError(sizeout) || sizeout > kFileMaxSize) {
+    return -1;
+  }
+
+  auto bufout = std::make_unique<int8_t[]>(sizeout);
+
+  size_t desize = ZSTD_decompress(bufout.get(), sizeout, bufin.get(), sizein);
+  if (ZSTD_isError(desize) || desize != sizeout) {
+    return -1;
+  }
+
+  if (write(fdout, bufout.get(), sizeout) != sizeout) {
+    return -1;
+  }
+
+  return 0;
+}
+
+int ZSTD_decompressStream_fd(ZSTD_DCtx* dctx, int fdin, int fdout) {
+  size_t sizein = ZSTD_CStreamInSize();
+  size_t sizeout = ZSTD_CStreamOutSize();
+
+  auto bufin = std::make_unique<int8_t[]>(sizein);
+  auto bufout = std::make_unique<int8_t[]>(sizeout);
+
+  ssize_t size;
+  while ((size = read(fdin, bufin.get(), sizein)) > 0) {
+    ZSTD_inBuffer_s struct_in;
+    struct_in.src = bufin.get();
+    struct_in.pos = 0;
+    struct_in.size = size;
+
+    while (struct_in.pos < size) {
+      ZSTD_outBuffer_s struct_out;
+      struct_out.dst = bufout.get();
+      struct_out.pos = 0;
+      struct_out.size = sizeout;
+
+      size_t ret = ZSTD_decompressStream(dctx, &struct_out, &struct_in);
+      if (ZSTD_isError(ret)) {
+        return -1;
+      }
+      if (write(fdout, bufout.get(), struct_out.pos) != struct_out.pos) {
+        return -1;
+      }
+    }
+  }
+
+  if (size != 0) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/contrib/zstd/wrapper/wrapper_zstd.h
+++ b/contrib/zstd/wrapper/wrapper_zstd.h
@@ -1,0 +1,28 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONTRIB_ZSTD_WRAPPER_WRAPPER_ZSTD_H_
+#define CONTRIB_ZSTD_WRAPPER_WRAPPER_ZSTD_H_
+
+#include "zstd.h"
+
+extern "C" {
+int ZSTD_compress_fd(int fdin, int fdout, int level);
+int ZSTD_compressStream_fd(ZSTD_CCtx* cctx, int fdin, int fdout);
+
+int ZSTD_decompress_fd(int fdin, int fdout);
+int ZSTD_decompressStream_fd(ZSTD_DCtx* dctx, int fdin, int fdout);
+};
+
+#endif  // CONTRIB_ZSTD_WRAPPER_WRAPPER_ZSTD_H_


### PR DESCRIPTION
The goal is to use a file descriptor as an input for ZStandard
library. Thanks to that we shouldn't send a chunk of memory over
expensive protocol.

Please notice this change depends on:
https://github.com/google/sandboxed-api/pull/106
https://github.com/google/sandboxed-api/pull/107

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/sandboxed-api/108)
<!-- Reviewable:end -->
