### PR TITLE
ZStandard: Optimize passing the memory

### DIFF
--- a/contrib/zstd/utils/utils_zstd.cc
+++ b/contrib/zstd/utils/utils_zstd.cc
@@ -80,7 +80,7 @@ absl::Status DecompressInMemory(ZstdApi& api, std::ifstream& in_stream,
 
   SAPI_ASSIGN_OR_RETURN(
       size_t desize, api.ZSTD_decompress(outbuf.PtrAfter(), size,
-                                         inbuf.PtrBefore(), inbuf.GetSize()));
+                                         inbuf.PtrNone(), inbuf.GetSize()));
   SAPI_ASSIGN_OR_RETURN(iserr, api.ZSTD_isError(desize));
   if (iserr) {
     return absl::UnavailableError("Unable to decompress file");


### PR DESCRIPTION
In the case of decompression, we are using the same chunk of memory
twice. The first is to obtain the size of decompressed data, and
the second is to decompress it. In the current code, we are copying
the chunk of memory twice. The memory doesn't change between
the calls, so there is no point in copying it over and over.
After this patch, the memory should be copied only once.