### PR TITLE
Add CMakeLists.txt for six libraries

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -18,8 +18,11 @@ set(SAPI_CONTRIB_SANDBOXES
   hunspell
   jsonnet
   libidn2
+  libraw
+  libvmaf
   libzip
   pffft
+  tesseract-ocr
   turbojpeg
   uriparser
   zopfli

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -15,6 +15,7 @@
 # Append to this list whenever a new sandboxed library is added to `contrib/`.
 set(SAPI_CONTRIB_SANDBOXES
   c-blosc
+  dav1d
   hunspell
   jsonnet
   libidn2

--- a/contrib/c-blosc/CMakeLists.txt
+++ b/contrib/c-blosc/CMakeLists.txt
@@ -29,6 +29,7 @@ if(NOT TARGET sapi::sapi)
 endif()
 
 set(HIDE_SYMBOLS OFF CACHE BOOL "" FORCE)
+set(PREFER_EXTERNAL_ZLIB ON CACHE BOOL "" FORCE) # prevent undefined symbol errors
 FetchContent_Declare(
   libblosc
 

--- a/contrib/dav1d/CMakeLists.txt
+++ b/contrib/dav1d/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.13..3.22)
+project(dav1d-sapi CXX C)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+if(NOT TARGET sapi::sapi)
+  set(SAPI_ROOT "../.." CACHE PATH "Path to the Sandboxed API source tree")
+  add_subdirectory("${SAPI_ROOT}"
+                   "${CMAKE_BINARY_DIR}/sandboxed-api-build"
+                   EXCLUDE_FROM_ALL)
+endif()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(dav1d REQUIRED IMPORTED_TARGET dav1d)
+
+add_sapi_library(dav1d_sapi
+  INPUTS
+    "${dav1d_INCLUDEDIR}/dav1d/common.h"
+    "${dav1d_INCLUDEDIR}/dav1d/picture.h"
+    "${dav1d_INCLUDEDIR}/dav1d/dav1d.h"
+    "${dav1d_INCLUDEDIR}/dav1d/data.h"
+  LIBRARY dav1d
+  FUNCTIONS
+    dav1d_data_create
+    dav1d_data_wrap
+    dav1d_data_wrap_user_data
+    dav1d_data_unref
+    dav1d_version
+    dav1d_open
+    dav1d_parse_sequence_header
+    dav1d_send_data
+    dav1d_get_picture
+    dav1d_close
+    dav1d_flush
+    dav1d_get_event_flags
+    dav1d_picture_unref
+  LIBRARY_NAME dav1d
+  NAMESPACE "dav1d_sapi"
+)
+add_library(sapi_contrib::dav1d ALIAS dav1d_sapi)
+target_include_directories(dav1d_sapi INTERFACE
+  "${PROJECT_BINARY_DIR}"
+)

--- a/contrib/jsonnet/CMakeLists.txt
+++ b/contrib/jsonnet/CMakeLists.txt
@@ -29,7 +29,7 @@ FetchContent_Declare(jsonnet
   GIT_REPOSITORY https://github.com/google/jsonnet.git
   GIT_TAG        v0.18.0 # 2021-12-21
 )
-option(BUILD_TESTS "" OFF) # Do not build jsonnet tests
+set(BUILD_TESTS OFF CACHE BOOL "" FORCE) # Do not build jsonnet tests
 FetchContent_MakeAvailable(jsonnet)
 create_directory_symlink("${jsonnet_SOURCE_DIR}"
                          "${PROJECT_BINARY_DIR}/jsonnet")

--- a/contrib/jsonnet/examples/jsonnet_base_example.cc
+++ b/contrib/jsonnet/examples/jsonnet_base_example.cc
@@ -25,7 +25,7 @@ absl::Status JsonnetMain(std::string in_file, std::string out_file) {
 
   // Initialize sandbox.
   JsonnetBaseSandbox sandbox(in_file, out_file);
-  SAPI_RETURN_IF_ERROR(sandbox.Init())
+  SAPI_RETURN_IF_ERROR(sandbox.Init());
 
   JsonnetApi api(&sandbox);
 

--- a/contrib/jsonnet/examples/jsonnet_formatter_example.cc
+++ b/contrib/jsonnet/examples/jsonnet_formatter_example.cc
@@ -58,7 +58,7 @@ absl::Status JsonnetMain(std::string in_file, std::string out_file) {
 
   // Initialize sandbox.
   JsonnetSapiSandbox sandbox(in_file, out_file);
-  SAPI_RETURN_IF_ERROR(sandbox.Init())
+  SAPI_RETURN_IF_ERROR(sandbox.Init());
 
   JsonnetApi api(&sandbox);
 

--- a/contrib/jsonnet/examples/jsonnet_multiple_files_example.cc
+++ b/contrib/jsonnet/examples/jsonnet_multiple_files_example.cc
@@ -60,7 +60,7 @@ absl::Status JsonnetMain(std::string in_file, std::string out_file) {
 
   // Initialize sandbox.
   JsonnetSapiSandbox sandbox(in_file, out_file);
-  SAPI_RETURN_IF_ERROR(sandbox.Init())
+  SAPI_RETURN_IF_ERROR(sandbox.Init());
 
   JsonnetApi api(&sandbox);
 

--- a/contrib/jsonnet/examples/jsonnet_yaml_stream_example.cc
+++ b/contrib/jsonnet/examples/jsonnet_yaml_stream_example.cc
@@ -25,7 +25,7 @@ absl::Status JsonnetMain(std::string in_file, std::string out_file) {
 
   // Initialize sandbox.
   JsonnetBaseSandbox sandbox(in_file, out_file);
-  SAPI_RETURN_IF_ERROR(sandbox.Init())
+  SAPI_RETURN_IF_ERROR(sandbox.Init());
 
   JsonnetApi api(&sandbox);
 

--- a/contrib/libraw/CMakeLists.txt
+++ b/contrib/libraw/CMakeLists.txt
@@ -1,0 +1,95 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.13..3.22)
+project(libraw-sapi CXX C)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+if(NOT TARGET sapi::sapi)
+  set(SAPI_ROOT "../.." CACHE PATH "Path to the Sandboxed API source tree")
+  add_subdirectory("${SAPI_ROOT}"
+                   "${CMAKE_BINARY_DIR}/sandboxed-api-build"
+                   EXCLUDE_FROM_ALL)
+endif()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBRAW REQUIRED IMPORTED_TARGET libraw)
+
+add_sapi_library(libraw_sapi
+  INPUTS "${LIBRAW_INCLUDEDIR}/libraw/libraw.h"
+  LIBRARY raw
+  FUNCTIONS
+    libraw_COLOR
+    libraw_adjust_sizes_info_only
+    libraw_cameraCount
+    libraw_cameraList
+    libraw_capabilities
+    libraw_close
+    libraw_dcraw_clear_mem
+    libraw_dcraw_make_mem_image
+    libraw_dcraw_make_mem_thumb
+    libraw_dcraw_ppm_tiff_writer
+    libraw_dcraw_process
+    libraw_dcraw_thumb_writer
+    libraw_free_image
+    libraw_get_cam_mul
+    libraw_get_color_maximum
+    libraw_get_decoder_info
+    libraw_get_iheight
+    libraw_get_imgother
+    libraw_get_iparams
+    libraw_get_iwidth
+    libraw_get_lensinfo
+    libraw_get_pre_mul
+    libraw_get_raw_height
+    libraw_get_raw_width
+    libraw_get_rgb_cam
+    libraw_init
+    libraw_open_buffer
+    libraw_open_file
+    libraw_open_file_ex
+    libraw_raw2image
+    libraw_recycle
+    libraw_recycle_datastream
+    libraw_set_bright
+    libraw_set_dataerror_handler
+    libraw_set_demosaic
+    libraw_set_exifparser_handler
+    libraw_set_fbdd_noiserd
+    libraw_set_gamma
+    libraw_set_highlight
+    libraw_set_memerror_handler
+    libraw_set_no_auto_bright
+    libraw_set_output_bps
+    libraw_set_output_color
+    libraw_set_output_tif
+    libraw_set_progress_handler
+    libraw_set_user_mul
+    libraw_strerror
+    libraw_strprogress
+    libraw_subtract_black
+    libraw_unpack
+    libraw_unpack_function_name
+    libraw_unpack_thumb
+    libraw_version
+    libraw_versionNumber
+  LIBRARY_NAME libraw 
+  NAMESPACE "libraw_sapi"
+)
+add_library(sapi_contrib::libraw ALIAS libraw_sapi)
+target_include_directories(libraw_sapi INTERFACE
+  "${PROJECT_BINARY_DIR}"
+)

--- a/contrib/libvmaf/CMakeLists.txt
+++ b/contrib/libvmaf/CMakeLists.txt
@@ -1,0 +1,128 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.13..3.22)
+project(libvmaf-sapi CXX C)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+if(NOT TARGET sapi::sapi)
+  set(SAPI_ROOT "../.." CACHE PATH "Path to the Sandboxed API source tree")
+  add_subdirectory("${SAPI_ROOT}"
+                   "${CMAKE_BINARY_DIR}/sandboxed-api-build"
+                   EXCLUDE_FROM_ALL)
+endif()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBVMAF REQUIRED IMPORTED_TARGET libvmaf)
+
+add_sapi_library(libvmaf_sapi
+  INPUTS "${LIBVMAF_INCLUDEDIR}/libvmaf/libvmaf.h"
+  LIBRARY vmaf
+  FUNCTIONS
+    vmaf_ceiln
+    vmaf_close
+    vmaf_dictionary_compare
+    vmaf_dictionary_copy
+    vmaf_dictionary_free
+    vmaf_dictionary_get
+    vmaf_dictionary_merge
+    vmaf_dictionary_set
+    vmaf_feature_collector_append
+    vmaf_feature_collector_append_templated
+    vmaf_feature_collector_destroy
+    vmaf_feature_collector_get_aggregate
+    vmaf_feature_collector_get_score
+    vmaf_feature_collector_init
+    vmaf_feature_collector_set_aggregate
+    vmaf_feature_dictionary_set
+    vmaf_feature_extractor_context_close
+    vmaf_feature_extractor_context_create
+    vmaf_feature_extractor_context_destroy
+    vmaf_feature_extractor_context_extract
+    vmaf_feature_extractor_context_flush
+    vmaf_feature_extractor_context_init
+    vmaf_feature_name
+    vmaf_feature_name_alias
+    vmaf_feature_score_at_index
+    vmaf_feature_score_pooled
+    vmaf_fex_ctx_parse_options
+    vmaf_fex_ctx_pool_aquire
+    vmaf_fex_ctx_pool_create
+    vmaf_fex_ctx_pool_destroy
+    vmaf_fex_ctx_pool_flush
+    vmaf_fex_ctx_pool_release
+    vmaf_floorn
+    vmaf_get_cpu_flags
+    vmaf_get_cpu_flags_x86
+    vmaf_get_feature_extractor_by_feature_name
+    vmaf_get_feature_extractor_by_name
+    vmaf_import_feature_score
+    vmaf_init
+    vmaf_init_cpu
+    vmaf_log
+    vmaf_model_collection_append
+    vmaf_model_collection_destroy
+    vmaf_model_collection_feature_overload
+    vmaf_model_collection_load
+    vmaf_model_collection_load_from_path
+    vmaf_model_destroy
+    vmaf_model_feature_overload
+    vmaf_model_generate_name
+    vmaf_model_load
+    vmaf_model_load_from_path
+    vmaf_option_set
+    vmaf_picture_alloc
+    vmaf_picture_ref
+    vmaf_picture_unref
+    vmaf_predict_score_at_index
+    vmaf_predict_score_at_index_model_collection
+    vmaf_read_json_model_collection_from_buffer
+    vmaf_read_json_model_collection_from_path
+    vmaf_read_json_model_from_buffer
+    vmaf_read_json_model_from_path
+    vmaf_read_pictures
+    vmaf_ref_close
+    vmaf_ref_fetch_decrement
+    vmaf_ref_fetch_increment
+    vmaf_ref_init
+    vmaf_ref_load
+    vmaf_score_at_index
+    vmaf_score_at_index_model_collection
+    vmaf_score_pooled
+    vmaf_score_pooled_model_collection
+    vmaf_set_cpu_flags_mask
+    vmaf_set_log_level
+    vmaf_thread_pool_create
+    vmaf_thread_pool_destroy
+    vmaf_thread_pool_enqueue
+    vmaf_thread_pool_wait
+    vmaf_use_feature
+    vmaf_use_features_from_model
+    vmaf_use_features_from_model_collection
+    vmaf_use_vmafossexec_aliases
+    vmaf_version
+    vmaf_write_output
+    vmaf_write_output_csv
+    vmaf_write_output_json
+    vmaf_write_output_sub
+    vmaf_write_output_xml
+  LIBRARY_NAME LibVMAF
+  NAMESPACE "libvmaf_sapi"
+)
+add_library(sapi_contrib::vmaf ALIAS libvmaf_sapi)
+target_include_directories(libvmaf_sapi INTERFACE
+  "${PROJECT_BINARY_DIR}"
+)

--- a/contrib/libzip/CMakeLists.txt
+++ b/contrib/libzip/CMakeLists.txt
@@ -27,6 +27,7 @@ if(NOT TARGET sapi::sapi)
 endif()
 
 set(BUILD_SHARED_LIBS off)
+set(LIBZIP_DO_INSTALL off)
 FetchContent_Declare(libzip
   GIT_REPOSITORY https://github.com/nih-at/libzip/
   GIT_TAG        34b13ca4e887a5aba050015e3a179069643f4e76
@@ -72,8 +73,6 @@ add_sapi_library(
 
     zip_strerror
   INPUTS
-    "${libzip_BINARY_DIR}/zipconf.h"
-    "${libzip_SOURCE_DIR}/lib/zip.h"
     "wrapper/wrapper_zip.h"
 
   LIBRARY wrapper_zip

--- a/contrib/libzip/sandboxed.h
+++ b/contrib/libzip/sandboxed.h
@@ -20,11 +20,6 @@
 
 #include <memory>
 
-// Note: This header is required because of the bug in generator. The generator
-// for some reason doesn't catch the types defined by zip (for example
-// zip_uint32_t).
-#include <zipconf.h>  // NOLINT(build/include_order)
-
 #include "sapi_zip.sapi.h"  // NOLINT(build/include)
 
 class ZipSapiSandbox : public ZipSandbox {

--- a/contrib/pffft/main_pffft_sandboxed.cc
+++ b/contrib/pffft/main_pffft_sandboxed.cc
@@ -26,9 +26,6 @@
 #include "absl/flags/flag.h"
 #include "sandboxed_api/vars.h"
 
-ABSL_DECLARE_FLAG(string, sandbox2_danger_danger_permit_all);
-ABSL_DECLARE_FLAG(string, sandbox2_danger_danger_permit_all_and_log);
-
 class PffftSapiSandbox : public PffftSandbox {
  public:
   std::unique_ptr<sandbox2::Policy> ModifyPolicy(sandbox2::PolicyBuilder*) {

--- a/contrib/tesseract-ocr/CMakeLists.txt
+++ b/contrib/tesseract-ocr/CMakeLists.txt
@@ -26,7 +26,10 @@ if(NOT TARGET sapi::sapi)
 endif()
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(tesseract REQUIRED IMPORTED_TARGET tesseract)
+pkg_check_modules(tesseract IMPORTED_TARGET tesseract)
+if(NOT tesseract_FOUND)
+  return()
+endif()
 
 add_sapi_library(tesseract_sapi
   INPUTS "${tesseract_INCLUDEDIR}/tesseract/capi.h"
@@ -94,8 +97,8 @@ add_sapi_library(tesseract_sapi
     TessBaseAPINumDawgs
     TessBaseAPIOem
 # these crash the code generator
-#   TessBaseAPIPrintVariables
-#   TessBaseAPIPrintVariablesToFile
+    TessBaseAPIPrintVariables
+    TessBaseAPIPrintVariablesToFile
     TessBaseAPIProcessPage
     TessBaseAPIProcessPages
     TessBaseAPIReadConfigFile

--- a/contrib/tesseract-ocr/CMakeLists.txt
+++ b/contrib/tesseract-ocr/CMakeLists.txt
@@ -93,8 +93,9 @@ add_sapi_library(tesseract_sapi
     TessBaseAPIMeanTextConf
     TessBaseAPINumDawgs
     TessBaseAPIOem
-    TessBaseAPIPrintVariables
-    TessBaseAPIPrintVariablesToFile
+# these crash the code generator
+#   TessBaseAPIPrintVariables
+#   TessBaseAPIPrintVariablesToFile
     TessBaseAPIProcessPage
     TessBaseAPIProcessPages
     TessBaseAPIReadConfigFile
@@ -185,10 +186,20 @@ add_sapi_library(tesseract_sapi
     TessUnlvRendererCreate
     TessVersion
     TessWordStrBoxRendererCreate
-  LIBRARY_NAME Tesseract
-  NAMESPACE "tesseract_sapi"
+  LIBRARY_NAME Tess
+  NAMESPACE "tess_sapi"
 )
 add_library(sapi_contrib::tesseract ALIAS tesseract_sapi)
 target_include_directories(tesseract_sapi INTERFACE
   "${PROJECT_BINARY_DIR}"
 )
+if(SAPI_ENABLE_TESTS)
+  add_executable(tesseract_sapi_test
+    sapi_tesseract_test.cc
+  )
+  target_link_libraries(tesseract_sapi_test PRIVATE
+    sapi_contrib::tesseract
+    sapi::test_main
+  )
+  gtest_discover_tests(tesseract_sapi_test)
+endif()

--- a/contrib/tesseract-ocr/CMakeLists.txt
+++ b/contrib/tesseract-ocr/CMakeLists.txt
@@ -1,0 +1,194 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.13..3.22)
+project(tesseract-sapi CXX C)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+if(NOT TARGET sapi::sapi)
+  set(SAPI_ROOT "../.." CACHE PATH "Path to the Sandboxed API source tree")
+  add_subdirectory("${SAPI_ROOT}"
+                   "${CMAKE_BINARY_DIR}/sandboxed-api-build"
+                   EXCLUDE_FROM_ALL)
+endif()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(tesseract REQUIRED IMPORTED_TARGET tesseract)
+
+add_sapi_library(tesseract_sapi
+  INPUTS "${tesseract_INCLUDEDIR}/tesseract/capi.h"
+  LIBRARY tesseract
+  FUNCTIONS
+    TessAltoRendererCreate
+    TessBaseAPIAdaptToWordStr
+    TessBaseAPIAllWordConfidences
+    TessBaseAPIAnalyseLayout
+    TessBaseAPIClear
+    TessBaseAPIClearAdaptiveClassifier
+    TessBaseAPIClearPersistentCache
+    TessBaseAPICreate
+    TessBaseAPIDelete
+    TessBaseAPIDetectOrientationScript
+    TessBaseAPIEnd
+    TessBaseAPIFindLinesCreateBlockList
+    TessBaseAPIGetAltoText
+    TessBaseAPIGetAvailableLanguagesAsVector
+    TessBaseAPIGetBoolVariable
+    TessBaseAPIGetBoxText
+    TessBaseAPIGetComponentImages
+    TessBaseAPIGetComponentImages1
+    TessBaseAPIGetConnectedComponents
+    TessBaseAPIGetDatapath
+    TessBaseAPIGetDawg
+    TessBaseAPIGetDoubleVariable
+    TessBaseAPIGetFeaturesForBlob
+    TessBaseAPIGetHOCRText
+    TessBaseAPIGetInitLanguagesAsString
+    TessBaseAPIGetInputImage
+    TessBaseAPIGetInputName
+    TessBaseAPIGetIntVariable
+    TessBaseAPIGetIterator
+    TessBaseAPIGetLSTMBoxText
+    TessBaseAPIGetLoadedLanguagesAsVector
+    TessBaseAPIGetMutableIterator
+    TessBaseAPIGetOpenCLDevice
+    TessBaseAPIGetPageSegMode
+    TessBaseAPIGetRegions
+    TessBaseAPIGetSourceYResolution
+    TessBaseAPIGetStringVariable
+    TessBaseAPIGetStrips
+    TessBaseAPIGetTextDirection
+    TessBaseAPIGetTextlines
+    TessBaseAPIGetTextlines1
+    TessBaseAPIGetThresholdedImage
+    TessBaseAPIGetThresholdedImageScaleFactor
+    TessBaseAPIGetTsvText
+    TessBaseAPIGetUNLVText
+    TessBaseAPIGetUTF8Text
+    TessBaseAPIGetUnichar
+    TessBaseAPIGetVariableAsString
+    TessBaseAPIGetWordStrBoxText
+    TessBaseAPIGetWords
+    TessBaseAPIInit1
+    TessBaseAPIInit2
+    TessBaseAPIInit3
+    TessBaseAPIInit4
+    TessBaseAPIInitForAnalysePage
+    TessBaseAPIInitLangMod
+    TessBaseAPIInitTruthCallback
+    TessBaseAPIIsValidWord
+    TessBaseAPIMeanTextConf
+    TessBaseAPINumDawgs
+    TessBaseAPIOem
+    TessBaseAPIPrintVariables
+    TessBaseAPIPrintVariablesToFile
+    TessBaseAPIProcessPage
+    TessBaseAPIProcessPages
+    TessBaseAPIReadConfigFile
+    TessBaseAPIReadDebugConfigFile
+    TessBaseAPIRecognize
+    TessBaseAPIRecognizeForChopTest
+    TessBaseAPIRect
+    TessBaseAPIRunAdaptiveClassifier
+    TessBaseAPISetDebugVariable
+    TessBaseAPISetDictFunc
+    TessBaseAPISetImage
+    TessBaseAPISetImage2
+    TessBaseAPISetInputImage
+    TessBaseAPISetInputName
+    TessBaseAPISetMinOrientationMargin
+    TessBaseAPISetOutputName
+    TessBaseAPISetPageSegMode
+    TessBaseAPISetProbabilityInContextFunc
+    TessBaseAPISetRectangle
+    TessBaseAPISetSourceResolution
+    TessBaseAPISetThresholder
+    TessBaseAPISetVariable
+    TessBaseGetBlockTextOrientations
+    TessBoxTextRendererCreate
+    TessChoiceIteratorConfidence
+    TessChoiceIteratorDelete
+    TessChoiceIteratorGetUTF8Text
+    TessChoiceIteratorNext
+    TessDeleteBlockList
+    TessDeleteIntArray
+    TessDeleteResultRenderer
+    TessDeleteText
+    TessDeleteTextArray
+    TessFindRowForBox
+    TessHOcrRendererCreate
+    TessHOcrRendererCreate2
+    TessLSTMBoxRendererCreate
+    TessMakeTBLOB
+    TessMakeTessOCRRow
+    TessMonitorCreate
+    TessMonitorDelete
+    TessMonitorGetCancelThis
+    TessMonitorGetProgress
+    TessMonitorSetCancelFunc
+    TessMonitorSetCancelThis
+    TessMonitorSetDeadlineMSecs
+    TessMonitorSetProgressFunc
+    TessNormalizeTBLOB
+    TessPDFRendererCreate
+    TessPageIteratorBaseline
+    TessPageIteratorBegin
+    TessPageIteratorBlockType
+    TessPageIteratorBoundingBox
+    TessPageIteratorCopy
+    TessPageIteratorDelete
+    TessPageIteratorGetBinaryImage
+    TessPageIteratorGetImage
+    TessPageIteratorIsAtBeginningOf
+    TessPageIteratorIsAtFinalElement
+    TessPageIteratorNext
+    TessPageIteratorOrientation
+    TessPageIteratorParagraphInfo
+    TessResultIteratorConfidence
+    TessResultIteratorCopy
+    TessResultIteratorDelete
+    TessResultIteratorGetChoiceIterator
+    TessResultIteratorGetPageIterator
+    TessResultIteratorGetPageIteratorConst
+    TessResultIteratorGetUTF8Text
+    TessResultIteratorNext
+    TessResultIteratorSymbolIsDropcap
+    TessResultIteratorSymbolIsSubscript
+    TessResultIteratorSymbolIsSuperscript
+    TessResultIteratorWordFontAttributes
+    TessResultIteratorWordIsFromDictionary
+    TessResultIteratorWordIsNumeric
+    TessResultIteratorWordRecognitionLanguage
+    TessResultRendererAddImage
+    TessResultRendererBeginDocument
+    TessResultRendererEndDocument
+    TessResultRendererExtention
+    TessResultRendererImageNum
+    TessResultRendererInsert
+    TessResultRendererNext
+    TessResultRendererTitle
+    TessTextRendererCreate
+    TessTsvRendererCreate
+    TessUnlvRendererCreate
+    TessVersion
+    TessWordStrBoxRendererCreate
+  LIBRARY_NAME Tesseract
+  NAMESPACE "tesseract_sapi"
+)
+add_library(sapi_contrib::tesseract ALIAS tesseract_sapi)
+target_include_directories(tesseract_sapi INTERFACE
+  "${PROJECT_BINARY_DIR}"
+)

--- a/contrib/tesseract-ocr/sapi_tesseract.h
+++ b/contrib/tesseract-ocr/sapi_tesseract.h
@@ -1,0 +1,46 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONTRIB_TESS_TESS_SAPI_H_
+#define CONTRIB_TESS_TESS_SAPI_H_
+
+#include <syscall.h>
+
+#include "sandboxed_api/util/fileops.h"
+#include "tesseract_sapi.sapi.h"  // NOLINT(build/include)
+namespace tess_sapi {
+class TessSapiSandbox : public tess_sapi::TessSandbox {
+ public:
+  std::unique_ptr<sandbox2::Policy> ModifyPolicy(
+      sandbox2::PolicyBuilder*) override {
+    return sandbox2::PolicyBuilder()
+        .AllowSystemMalloc()
+        .AllowRead()
+        .AllowStat()
+        .AllowWrite()
+        .AllowExit()
+        .AllowSyscalls({
+            __NR_futex,
+            __NR_close,
+            __NR_lseek,
+            __NR_getpid,
+            __NR_clock_gettime,
+        })
+        .AllowLlvmSanitizers()
+        .BuildOrDie();
+  }
+};
+}
+
+#endif  // CONTRIB_TESS_TESS_SAPI_H_

--- a/contrib/tesseract-ocr/sapi_tesseract_test.cc
+++ b/contrib/tesseract-ocr/sapi_tesseract_test.cc
@@ -1,0 +1,49 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "contrib/tesseract-ocr/sapi_tesseract.h"
+
+#include <optional>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "sandboxed_api/testing.h"
+#include "sandboxed_api/util/status_matchers.h"
+
+using ::sapi::IsOk;
+using ::testing::Not;
+using ::testing::StrEq;
+
+namespace {
+class TessSapiSandboxTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    sandbox_ = new tess_sapi::TessSapiSandbox();
+    ASSERT_THAT(sandbox_->Init(), IsOk());
+    lib_ = new tess_sapi::TessApi(sandbox_);
+  }
+  static void TearDownTestSuite() {
+    delete lib_;
+    delete sandbox_;
+  }
+  static tess_sapi::TessApi* lib_;
+
+ private:
+  static tess_sapi::TessSapiSandbox* sandbox_;
+};
+
+tess_sapi::TessApi* TessSapiSandboxTest::lib_;
+tess_sapi::TessSapiSandbox* TessSapiSandboxTest::sandbox_;
+}
+

--- a/contrib/turbojpeg/CMakeLists.txt
+++ b/contrib/turbojpeg/CMakeLists.txt
@@ -33,6 +33,14 @@ add_sapi_library(turbojpeg_sapi
   LIBRARY turbojpeg
   LIBRARY_NAME TurboJPEG
   NAMESPACE "turbojpeg_sapi"
+  FUNCTIONS
+   tjDestroy
+   tjGetErrorStr2
+   tjCompress2
+   tjInitCompress
+   tjInitDecompress
+   tjDecompressHeader3
+   tjDecompress2
 )
 add_library(sapi_contrib::turbojpeg ALIAS turbojpeg_sapi)
 target_include_directories(turbojpeg_sapi INTERFACE

--- a/contrib/zopfli/CMakeLists.txt
+++ b/contrib/zopfli/CMakeLists.txt
@@ -48,9 +48,6 @@ add_sapi_library(
 
     ZopfliCompressFD
   INPUTS
-    "${zopfli_SOURCE_DIR}/src/zopfli/deflate.h"
-    "${zopfli_SOURCE_DIR}/src/zopfli/gzip_container.h"
-    "${zopfli_SOURCE_DIR}/src/zopfli/zlib_container.h"
     wrapper/wrapper_zopfli.h
 
   LIBRARY wrapper_zopfli

--- a/contrib/zstd/CMakeLists.txt
+++ b/contrib/zstd/CMakeLists.txt
@@ -78,7 +78,6 @@ add_sapi_library(
     ZSTD_decompress_fd
     ZSTD_decompressStream_fd
   INPUTS
-    "${libzstd_INCLUDE_DIR}/zstd.h"
     wrapper/wrapper_zstd.h
 
   LIBRARY wrapper_zstd


### PR DESCRIPTION
c-ares, dav1d, libraw, libvmaf, miniz, and tesseract-ocr are included.  dav1d is not very useful as the code generator crashes, so I had to disable wrapping `dav1d_open`.