### PR TITLE
Remove trailing semicolons from macros

### DIFF
--- a/contrib/zstd/utils/utils_zstd.cc
+++ b/contrib/zstd/utils/utils_zstd.cc
@@ -44,7 +44,7 @@ absl::Status CompressInMemory(ZstdApi& api, std::ifstream& in_stream,
       size_t outsize,
       api.ZSTD_compress(outbuf.PtrAfter(), size, inbuf.PtrBefore(),
                         inbuf.GetSize(), level));
-  SAPI_ASSIGN_OR_RETURN(int iserr, api.ZSTD_isError(outsize))
+  SAPI_ASSIGN_OR_RETURN(int iserr, api.ZSTD_isError(outsize));
   if (iserr) {
     return absl::UnavailableError("Unable to compress file");
   }
@@ -115,13 +115,13 @@ absl::Status CompressStream(ZstdApi& api, std::ifstream& in_stream,
 
   SAPI_ASSIGN_OR_RETURN(iserr, api.ZSTD_CCtx_setParameter(
                                    &rcctx, ZSTD_c_compressionLevel, level));
-  SAPI_ASSIGN_OR_RETURN(iserr, api.ZSTD_isError(iserr))
+  SAPI_ASSIGN_OR_RETURN(iserr, api.ZSTD_isError(iserr));
   if (iserr) {
     return absl::UnavailableError("Unable to set parameter");
   }
   SAPI_ASSIGN_OR_RETURN(
       iserr, api.ZSTD_CCtx_setParameter(&rcctx, ZSTD_c_checksumFlag, 1));
-  SAPI_ASSIGN_OR_RETURN(iserr, api.ZSTD_isError(iserr))
+  SAPI_ASSIGN_OR_RETURN(iserr, api.ZSTD_isError(iserr));
   if (iserr) {
     return absl::UnavailableError("Unable to set parameter");
   }
@@ -155,7 +155,7 @@ absl::Status CompressStream(ZstdApi& api, std::ifstream& in_stream,
       SAPI_ASSIGN_OR_RETURN(size_t remaining, api.ZSTD_compressStream2(
                                                   &rcctx, struct_out.PtrBoth(),
                                                   struct_in.PtrBoth(), mode));
-      SAPI_ASSIGN_OR_RETURN(int iserr, api.ZSTD_isError(remaining))
+      SAPI_ASSIGN_OR_RETURN(int iserr, api.ZSTD_isError(remaining));
       if (iserr) {
         return absl::UnavailableError("Unable to decompress file");
       }
@@ -220,7 +220,7 @@ absl::Status DecompressStream(ZstdApi& api, std::ifstream& in_stream,
       SAPI_ASSIGN_OR_RETURN(
           size_t ret, api.ZSTD_decompressStream(&rdctx, struct_out.PtrBoth(),
                                                 struct_in.PtrBoth()));
-      SAPI_ASSIGN_OR_RETURN(int iserr, api.ZSTD_isError(ret))
+      SAPI_ASSIGN_OR_RETURN(int iserr, api.ZSTD_isError(ret));
       if (iserr) {
         return absl::UnavailableError("Unable to decompress file");
       }
@@ -250,7 +250,7 @@ absl::Status CompressInMemoryFD(ZstdApi& api, sapi::v::Fd& infd,
   SAPI_ASSIGN_OR_RETURN(
       int iserr,
       api.ZSTD_compress_fd(infd.GetRemoteFd(), outfd.GetRemoteFd(), 0));
-  SAPI_ASSIGN_OR_RETURN(iserr, api.ZSTD_isError(iserr))
+  SAPI_ASSIGN_OR_RETURN(iserr, api.ZSTD_isError(iserr));
   if (iserr) {
     return absl::UnavailableError("Unable to compress file");
   }
@@ -268,7 +268,7 @@ absl::Status DecompressInMemoryFD(ZstdApi& api, sapi::v::Fd& infd,
 
   SAPI_ASSIGN_OR_RETURN(int iserr, api.ZSTD_decompress_fd(infd.GetRemoteFd(),
                                                           outfd.GetRemoteFd()));
-  SAPI_ASSIGN_OR_RETURN(iserr, api.ZSTD_isError(iserr))
+  SAPI_ASSIGN_OR_RETURN(iserr, api.ZSTD_isError(iserr));
   if (iserr) {
     return absl::UnavailableError("Unable to compress file");
   }

--- a/sandboxed_api/util/status_macros.h
+++ b/sandboxed_api/util/status_macros.h
@@ -35,7 +35,7 @@
     if (ABSL_PREDICT_FALSE(!status.ok())) {     \
       return status;                            \
     }                                           \
-  } while (0);
+  } while (0)
 
 #define SAPI_ASSIGN_OR_RETURN(lhs, rexpr) \
   SAPI_ASSIGN_OR_RETURN_IMPL(             \
@@ -46,6 +46,6 @@
   if (ABSL_PREDICT_FALSE(!statusor.ok())) {              \
     return statusor.status();                            \
   }                                                      \
-  lhs = std::move(statusor).value();
+  lhs = std::move(statusor).value(); do; while (0)
 
 #endif  // THIRD_PARTY_SAPI_UTIL_STATUS_MACROS_H_


### PR DESCRIPTION
The semicolons should be in the code that uses the macros.