### PR TITLE
contrib: use constexpr for kFileMaxSize

### DIFF
--- a/contrib/c-blosc/utils/utils_blosc.cc
+++ b/contrib/c-blosc/utils/utils_blosc.cc
@@ -20,7 +20,7 @@
 
 #include "contrib/c-blosc/sandboxed.h"
 
-static const size_t kFileMaxSize = 1024 * 1024 * 1024;  // 1GB
+constexpr size_t kFileMaxSize = 1024 * 1024 * 1024;  // 1GB
 
 std::streamsize GetStreamSize(std::ifstream& stream) {
   stream.seekg(0, std::ios_base::end);

--- a/contrib/zstd/utils/utils_zstd.cc
+++ b/contrib/zstd/utils/utils_zstd.cc
@@ -18,7 +18,7 @@
 
 #include "contrib/zstd/sandboxed.h"
 
-static const size_t kFileMaxSize = 1024 * 1024 * 1024;  // 1GB
+constexpr size_t kFileMaxSize = 1024 * 1024 * 1024;  // 1GB
 
 std::streamsize GetStreamSize(std::ifstream& stream) {
   stream.seekg(0, std::ios_base::end);


### PR DESCRIPTION
Use constexpr to inform compiler that it is possible to evaluate
variable at compile time.