### PR TITLE
Introduce SAPI_ASSERT_OK

### DIFF
--- a/sandboxed_api/util/status_matchers.h
+++ b/sandboxed_api/util/status_matchers.h
@@ -23,6 +23,9 @@
 #include "absl/types/optional.h"
 #include "sandboxed_api/util/status_macros.h"
 
+#define SAPI_ASSERT_OK(expr)                                 \
+  ASSERT_THAT(expr, ::sapi::IsOk())
+
 #define SAPI_ASSERT_OK_AND_ASSIGN(lhs, rexpr) \
   SAPI_ASSERT_OK_AND_ASSIGN_IMPL(             \
       SAPI_MACROS_IMPL_CONCAT(_sapi_statusor, __LINE__), lhs, rexpr)


### PR DESCRIPTION
We have a SAPI_ASSERT_OK_AND_ASSIGN which corespondents to
SAPI_ASSIGN_OR_RETURN.

We also have SAPI_RETURN_IF_ERROR but we don't have a coresponding
macro for ASSERT.

I think that this completes the API and makes writting tests a little
bit simpler.