### PR TITLE
Use <sys/prctl.h> rather than <linux/prctl.h>.

### DIFF
--- a/sandboxed_api/sandbox2/forkserver.cc
+++ b/sandboxed_api/sandbox2/forkserver.cc
@@ -18,7 +18,6 @@
 
 #include <fcntl.h>
 #include <linux/filter.h>
-#include <linux/prctl.h>
 #include <linux/seccomp.h>
 #include <sched.h>
 #include <sys/prctl.h>

--- a/sandboxed_api/sandbox2/testcases/policy.cc
+++ b/sandboxed_api/sandbox2/testcases/policy.cc
@@ -14,7 +14,6 @@
 
 // A binary that tries x86_64 compat syscalls, ptrace and clone untraced.
 
-#include <linux/prctl.h>
 #include <sched.h>
 #include <sys/prctl.h>
 #include <sys/ptrace.h>


### PR DESCRIPTION
bionic and glibc's <sys/prctl.h> include <linux/prctl.h> for you anyway, while musl's <sys/prctl.h> and <linux/prctl.h> are incompatible, breaking Android's musl host build when we try to upgrade sandboxed-api.