### PR TITLE
Fix generator output for functions with a parameter named `ret`

### DIFF
--- a/sandboxed_api/tools/clang_generator/emitter.cc
+++ b/sandboxed_api/tools/clang_generator/emitter.cc
@@ -447,8 +447,10 @@ absl::StatusOr<std::string> Emitter::DoEmitFunction(
 
   absl::StrAppend(&out, ") {\n");
 
-  // Declare the return value of the SAPI function.
-  absl::StrAppend(&out, type_mapper.MapQualType(return_type), " v_ret_;\n");
+  // Declare the return value of the SAPI function. The variable is not
+  // suffixed with an underscore like the parameter variables below, so that a
+  // parameter named `ret` cannot collide with it.
+  absl::StrAppend(&out, type_mapper.MapQualType(return_type), " v_ret;\n");
 
   // Declare the local variables for the parameters.
   for (const auto& [qual, name] : params) {
@@ -460,7 +462,7 @@ absl::StatusOr<std::string> Emitter::DoEmitFunction(
 
   // Call the sandboxed function.
   absl::StrAppend(&out, "\nABSL_RETURN_IF_ERROR(sandbox_->Call(\"",
-                  function_name, "\", &v_ret_");
+                  function_name, "\", &v_ret");
   for (const auto& [qual, name] : params) {
     absl::StrAppend(&out, ", ", IsPointerOrReference(qual) ? "" : "&v_", name);
   }
@@ -468,7 +470,7 @@ absl::StatusOr<std::string> Emitter::DoEmitFunction(
   // End the sandboxed function call and return `ok` if the unsandboxed function
   // returns void, or else return the value of the SAPI function.
   absl::StrAppend(&out, "));\nreturn ",
-                  (returns_void ? "::absl::OkStatus()" : "v_ret_.GetValue()"),
+                  (returns_void ? "::absl::OkStatus()" : "v_ret.GetValue()"),
                   ";\n}\n");
   return out;
 }

--- a/sandboxed_api/tools/clang_generator/emitter_test.cc
+++ b/sandboxed_api/tools/clang_generator/emitter_test.cc
@@ -183,6 +183,27 @@ TEST_F(EmitterTest, AllFunctionsLimitScanDepthFailure) {
   EXPECT_THAT(emitter.GetRenderedFunctions(), IsEmpty());
 }
 
+// Tests that the generator produces valid code for functions that have a
+// parameter named `ret`. The local copy of the parameter and the return value
+// variable must not collide (both would be named `v_ret_`).
+TEST_F(EmitterTest, ParameterNamedRet) {
+  GeneratorOptions options;
+  EmitterForTesting emitter(&options);
+  ASSERT_THAT(RunFrontendAction(
+                  R"(extern "C" int FunctionWithRet(int ret);)",
+                  std::make_unique<GeneratorAction>(&emitter, &options)),
+              IsOk());
+  EXPECT_THAT(emitter.GetRenderedFunctions(), SizeIs(1));
+
+  absl::StatusOr<std::string> header = emitter.EmitHeader();
+  ASSERT_THAT(header, IsOk());
+  const std::string uglified = UglifyAll({*header})[0];
+
+  // The return value slot and the parameter copy must be passed to
+  // sandbox_->Call() as two distinct variables.
+  EXPECT_THAT(uglified, HasSubstr("&v_ret, &v_ret_"));
+}
+
 TEST_F(EmitterTest, RelatedTypes) {
   GeneratorOptions options;
   EmitterForTesting emitter(&options);


### PR DESCRIPTION
Fixes #142: the clang generator emits syntactically invalid wrapper code when a sandboxed function has a parameter named `ret`.

The client-side wrapper generated by `Emitter::DoEmitFunction()` declares the return-value slot as `v_ret_` and the local copy of each parameter as `v_<name>_`. For a parameter named `ret`, both variables end up named `v_ret_` in the same scope, so the generated header does not compile ("redeclaration of 'v_ret_'"). This breaks headers like libxslt's that use `ret` as a parameter name.

This change renames the return-value slot to `v_ret`. Parameter-derived variables always carry a trailing underscore, so `v_ret` can never collide with them.

Verified by compiling the generated wrapper for `int FunctionWithRet(int ret)` with g++: before the fix it fails with `error: redeclaration of 'sapi::v::Int v_ret_'`; after the fix it compiles cleanly. A regression test (`EmitterTest.ParameterNamedRet`) checks that the return slot and the parameter copy are passed to `sandbox_->Call()` as two distinct variables.