### PR TITLE
filewrapper: validate C++ namespace identifier (fixes #88)

### DIFF
--- a/sandboxed_api/tools/filewrapper/BUILD
+++ b/sandboxed_api/tools/filewrapper/BUILD
@@ -23,7 +23,10 @@ licenses(["notice"])
 # embedded data into .cc files.
 cc_binary(
     name = "filewrapper",
-    srcs = ["filewrapper.cc"],
+    srcs = [
+        "filewrapper.cc",
+        "filewrapper.h",
+    ],
     copts = sapi_platform_copts(),
     visibility = ["//visibility:public"],
     deps = [
@@ -49,7 +52,10 @@ sapi_cc_embed_data(
 
 cc_test(
     name = "filewrapper_test",
-    srcs = ["filewrapper_test.cc"],
+    srcs = [
+        "filewrapper.h",
+        "filewrapper_test.cc",
+    ],
     copts = sapi_platform_copts(),
     data = [":filewrapper_embedded.bin"],
     deps = [
@@ -59,7 +65,7 @@ cc_test(
         "//sandboxed_api:testing",
         "//sandboxed_api/sandbox2/util:minielf",
         "//sandboxed_api/util:file_helpers",
-        "@abseil-cpp//absl/strings:string_view",
+        "@abseil-cpp//absl/strings",
         "@googletest//:gtest_main",
     ],
 )

--- a/sandboxed_api/tools/filewrapper/CMakeLists.txt
+++ b/sandboxed_api/tools/filewrapper/CMakeLists.txt
@@ -15,6 +15,7 @@
 # sandboxed_api/tools/filewrapper:filewrapper
 add_executable(filewrapper
   filewrapper.cc
+  filewrapper.h
 )
 target_link_libraries(filewrapper PRIVATE
   absl::strings
@@ -33,6 +34,7 @@ if(BUILD_TESTING AND SAPI_BUILD_TESTING)
   # sandboxed_api/tools/filewrapper:filewrapper_test
   add_executable(sapi_filewrapper_test
     filewrapper_test.cc
+    filewrapper.h
   )
   set_target_properties(sapi_filewrapper_test PROPERTIES
     OUTPUT_NAME filewrapper_test

--- a/sandboxed_api/tools/filewrapper/filewrapper.cc
+++ b/sandboxed_api/tools/filewrapper/filewrapper.cc
@@ -27,7 +27,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_replace.h"
-#include "absl/strings/string_view.h"
+#include "sandboxed_api/tools/filewrapper/filewrapper.h"
 #include "sandboxed_api/util/fileops.h"
 #include "sandboxed_api/util/raw_logging.h"
 
@@ -307,6 +307,11 @@ int main(int argc, char* argv[]) {
   const char* ns = *arg++;
   const bool have_ns = strlen(ns) > 0;
   --argc;
+
+  if (have_ns && !sapi::IsValidNamespace(ns)) {
+    absl::FPrintF(stderr, "Error: Invalid C++ namespace identifier: '%s'\n", ns);
+    return EXIT_FAILURE;
+  }
 
   const char* out_h_path = *arg++;
   --argc;

--- a/sandboxed_api/tools/filewrapper/filewrapper.h
+++ b/sandboxed_api/tools/filewrapper/filewrapper.h
@@ -1,0 +1,161 @@
+﻿// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SANDBOXED_API_TOOLS_FILEWRAPPER_FILEWRAPPER_H_
+#define SANDBOXED_API_TOOLS_FILEWRAPPER_FILEWRAPPER_H_
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
+#include "absl/strings/ascii.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
+
+namespace sapi {
+
+inline bool IsCppKeyword(absl::string_view s) {
+  static constexpr absl::string_view kKeywords[] = {
+      "alignas",
+      "alignof",
+      "and",
+      "and_eq",
+      "asm",
+      "atomic_cancel",
+      "atomic_commit",
+      "atomic_noexcept",
+      "auto",
+      "bitand",
+      "bitor",
+      "bool",
+      "break",
+      "case",
+      "catch",
+      "char",
+      "char16_t",
+      "char32_t",
+      "char8_t",
+      "class",
+      "co_await",
+      "co_return",
+      "co_yield",
+      "compl",
+      "concept",
+      "const",
+      "const_cast",
+      "consteval",
+      "constexpr",
+      "constinit",
+      "continue",
+      "decltype",
+      "default",
+      "delete",
+      "do",
+      "double",
+      "dynamic_cast",
+      "else",
+      "enum",
+      "explicit",
+      "export",
+      "extern",
+      "false",
+      "float",
+      "for",
+      "friend",
+      "goto",
+      "if",
+      "inline",
+      "int",
+      "long",
+      "mutable",
+      "namespace",
+      "new",
+      "noexcept",
+      "not",
+      "not_eq",
+      "nullptr",
+      "operator",
+      "or",
+      "or_eq",
+      "private",
+      "protected",
+      "public",
+      "reflexpr",
+      "register",
+      "reinterpret_cast",
+      "requires",
+      "return",
+      "short",
+      "signed",
+      "sizeof",
+      "static",
+      "static_assert",
+      "static_cast",
+      "struct",
+      "switch",
+      "synchronized",
+      "template",
+      "this",
+      "thread_local",
+      "throw",
+      "true",
+      "try",
+      "typedef",
+      "typeid",
+      "typename",
+      "union",
+      "unsigned",
+      "using",
+      "virtual",
+      "void",
+      "volatile",
+      "wchar_t",
+      "while",
+      "xor",
+      "xor_eq",
+  };
+  return std::binary_search(std::begin(kKeywords), std::end(kKeywords), s);
+}
+
+inline bool IsValidCppIdentifier(absl::string_view ident) {
+  if (ident.empty()) {
+    return false;
+  }
+  if (!absl::ascii_isalpha(ident[0]) && ident[0] != '_') {
+    return false;
+  }
+  for (char c : ident) {
+    if (!absl::ascii_isalnum(c) && c != '_') {
+      return false;
+    }
+  }
+  return !IsCppKeyword(ident);
+}
+
+inline bool IsValidNamespace(absl::string_view ns) {
+  if (ns.empty()) {
+    return false;
+  }
+  std::vector<absl::string_view> parts = absl::StrSplit(ns, "::");
+  for (absl::string_view part : parts) {
+    if (!IsValidCppIdentifier(part)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace sapi
+
+#endif  // SANDBOXED_API_TOOLS_FILEWRAPPER_FILEWRAPPER_H_

--- a/sandboxed_api/tools/filewrapper/filewrapper_test.cc
+++ b/sandboxed_api/tools/filewrapper/filewrapper_test.cc
@@ -24,6 +24,7 @@
 #include "sandboxed_api/embed_toc.h"
 #include "sandboxed_api/sandbox2/util/minielf.h"
 #include "sandboxed_api/testing.h"
+#include "sandboxed_api/tools/filewrapper/filewrapper.h"
 #include "sandboxed_api/tools/filewrapper/filewrapper_embedded.h"
 
 namespace sapi {
@@ -67,6 +68,64 @@ TEST(FilewrapperTest, BasicFunctionality) {
   EXPECT_THAT(pread(fd, &materialized_contents[0], kExpectedPayload.size(), 0),
               Eq(kExpectedPayload.size()));
   EXPECT_THAT(materialized_contents, StrEq(kExpectedPayload));
+}
+
+TEST(FilewrapperTest, ValidatesCppIdentifier) {
+  // Valid identifiers
+  EXPECT_TRUE(IsValidCppIdentifier("foo"));
+  EXPECT_TRUE(IsValidCppIdentifier("_foo"));
+  EXPECT_TRUE(IsValidCppIdentifier("foo_123"));
+  EXPECT_TRUE(IsValidCppIdentifier("ABC"));
+  EXPECT_TRUE(IsValidCppIdentifier("_"));
+
+  // Invalid identifiers
+  EXPECT_FALSE(IsValidCppIdentifier(""));
+  EXPECT_FALSE(IsValidCppIdentifier("123foo"));
+  EXPECT_FALSE(IsValidCppIdentifier("foo-bar"));
+  EXPECT_FALSE(IsValidCppIdentifier("foo bar"));
+  EXPECT_FALSE(IsValidCppIdentifier("foo.bar"));
+  EXPECT_FALSE(IsValidCppIdentifier("foo::bar"));
+
+  // Keywords
+  EXPECT_FALSE(IsValidCppIdentifier("class"));
+  EXPECT_FALSE(IsValidCppIdentifier("namespace"));
+  EXPECT_FALSE(IsValidCppIdentifier("struct"));
+  EXPECT_FALSE(IsValidCppIdentifier("int"));
+  EXPECT_FALSE(IsValidCppIdentifier("return"));
+  EXPECT_FALSE(IsValidCppIdentifier("template"));
+  EXPECT_FALSE(IsValidCppIdentifier("typename"));
+  EXPECT_FALSE(IsValidCppIdentifier("const"));
+  EXPECT_FALSE(IsValidCppIdentifier("default"));
+}
+
+TEST(FilewrapperTest, ValidatesNamespace) {
+  // Valid namespaces
+  EXPECT_TRUE(IsValidNamespace("sapi"));
+  EXPECT_TRUE(IsValidNamespace("foo"));
+  EXPECT_TRUE(IsValidNamespace("_foo_123"));
+  EXPECT_TRUE(IsValidNamespace("sapi::tools::filewrapper"));
+  EXPECT_TRUE(IsValidNamespace("foo::bar::baz"));
+  EXPECT_TRUE(IsValidNamespace("A::B::C"));
+
+  // Invalid namespaces
+  EXPECT_FALSE(IsValidNamespace(""));
+  EXPECT_FALSE(IsValidNamespace("::foo"));
+  EXPECT_FALSE(IsValidNamespace("foo::"));
+  EXPECT_FALSE(IsValidNamespace("foo::::bar"));
+  EXPECT_FALSE(IsValidNamespace("123foo"));
+  EXPECT_FALSE(IsValidNamespace("foo-bar"));
+  EXPECT_FALSE(IsValidNamespace("foo.bar"));
+  EXPECT_FALSE(IsValidNamespace("foo bar"));
+  EXPECT_FALSE(IsValidNamespace("foo::123"));
+  EXPECT_FALSE(IsValidNamespace("foo::bar::"));
+
+  // Namespaces containing C++ keywords
+  EXPECT_FALSE(IsValidNamespace("class"));
+  EXPECT_FALSE(IsValidNamespace("int"));
+  EXPECT_FALSE(IsValidNamespace("namespace"));
+  EXPECT_FALSE(IsValidNamespace("sapi::namespace::foo"));
+  EXPECT_FALSE(IsValidNamespace("sapi::return"));
+  EXPECT_FALSE(IsValidNamespace("sapi::default::bar"));
 }
 
 }  // namespace


### PR DESCRIPTION
### Motivation
Fixes #88

The `filewrapper` tool generates C++ source and header files wrapped in a user-provided namespace (passed via `sapi_cc_embed_data(NAMESPACE "...")`).
Previously, the third argument (`ns`) was not validated at all, allowing invalid identifiers, illegal characters, or C++ reserved keywords to pass through unchecked, resulting in syntactically invalid generated code that fails only during subsequent compilation with confusing errors.

### Changes
1. **`sandboxed_api/tools/filewrapper/filewrapper.h`**:
   - Added `IsValidCppIdentifier(absl::string_view ident)` to check character legality (`[a-zA-Z_][a-zA-Z0-9_]*`) and reject standard C++ reserved keywords via `IsCppKeyword` (`std::binary_search`).
   - Added `IsValidNamespace(absl::string_view ns)` supporting both simple and nested C++ namespaces (e.g. `sapi::embed`) and rejecting empty parts or invalid segments.
2. **`sandboxed_api/tools/filewrapper/filewrapper.cc`**:
   - Included `filewrapper.h` and validated the namespace argument in `main()` when `have_ns` is true. If invalid, prints an informative error message and exits with `EXIT_FAILURE`.
3. **`sandboxed_api/tools/filewrapper/filewrapper_test.cc`**:
   - Added comprehensive unit tests (`ValidatesCppIdentifier` and `ValidatesNamespace`) covering valid identifiers/namespaces, illegal characters, edge cases (`::foo`, `foo::`, `foo::::bar`), and C++ keywords (`class`, `namespace`, `int`, etc.).
4. **`BUILD` and `CMakeLists.txt`**:
   - Included `filewrapper.h` in the corresponding build targets.
