### PR TITLE
clang_generator: report error when requested function does not exist (fixes #94)

### DIFF
--- a/sandboxed_api/tools/clang_generator/emitter_test.cc
+++ b/sandboxed_api/tools/clang_generator/emitter_test.cc
@@ -42,6 +42,7 @@ using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::IsEmpty;
 using ::testing::MatchesRegex;
+using ::testing::Not;
 using ::testing::SizeIs;
 using ::testing::StrEq;
 using ::testing::StrNe;
@@ -103,6 +104,20 @@ TEST_F(EmitterTest, SpecificFunctionRequested) {
   absl::StatusOr<std::string> header = emitter.EmitHeader();
   ASSERT_THAT(header, IsOk());
   EXPECT_THAT(*header, HasSubstr("ExposedFunction"));
+}
+
+// Tests that requesting a function that does not exist in the translation unit
+// fails with an error.
+TEST_F(EmitterTest, NonExistentFunctionFails) {
+  GeneratorOptions options;
+  options.set_function_names<std::initializer_list<std::string>>(
+      {"NonExistentFunction"});
+
+  EmitterForTesting emitter(&options);
+  EXPECT_THAT(RunFrontendActionOnFile(
+                  "simple_functions.cc",
+                  std::make_unique<GeneratorAction>(&emitter, &options)),
+              Not(IsOk()));
 }
 
 // Tests that the generator emits all functions if no specific functions are

--- a/sandboxed_api/tools/clang_generator/generator.cc
+++ b/sandboxed_api/tools/clang_generator/generator.cc
@@ -171,6 +171,9 @@ bool GeneratorASTVisitor::VisitFunctionDecl(clang::FunctionDecl* decl) {
       !options_.function_names.contains(ToStringView(decl->getName()))) {
     return true;
   }
+  if (!sandbox_all_functions) {
+    found_functions_.insert(std::string(ToStringView(decl->getName())));
+  }
 
   // Skip Abseil internal functions when all functions are requested. This still
   // allows them to be specified explicitly.
@@ -239,6 +242,18 @@ void GeneratorASTConsumer::HandleTranslationUnit(clang::ASTContext& context) {
   for (clang::FunctionDecl* func : visitor_.functions()) {
     absl::Status status = emitter_.AddFunction(func);
     ReportIfError(context, func->getBeginLoc(), status);
+  }
+
+  if (!options_.function_names.empty()) {
+    for (const std::string& name : options_.function_names) {
+      if (!visitor_.found_functions().contains(name)) {
+        Report(context.getDiagnostics(),
+               context.getTranslationUnitDecl()->getBeginLoc(),
+               clang::DiagnosticsEngine::Error,
+               absl::StrCat("Requested function '", name,
+                            "' not found in translation unit."));
+      }
+    }
   }
 }
 

--- a/sandboxed_api/tools/clang_generator/generator.h
+++ b/sandboxed_api/tools/clang_generator/generator.h
@@ -111,12 +111,17 @@ class GeneratorASTVisitor
     return functions_;
   }
 
+  const absl::flat_hash_set<std::string>& found_functions() const {
+    return found_functions_;
+  }
+
   const std::vector<clang::VarDecl*>& vars() const { return vars_; }
 
  private:
   TypeCollector type_collector_;
   std::vector<clang::FunctionDecl*> functions_;
   std::vector<clang::VarDecl*> vars_;
+  absl::flat_hash_set<std::string> found_functions_;
   const GeneratorOptions& options_;
 };
 
@@ -124,7 +129,10 @@ class GeneratorASTConsumer : public clang::ASTConsumer {
  public:
   GeneratorASTConsumer(std::string in_file, EmitterBase& emitter,
                        const GeneratorOptions& options)
-      : in_file_(std::move(in_file)), visitor_(options), emitter_(emitter) {}
+      : in_file_(std::move(in_file)),
+        visitor_(options),
+        emitter_(emitter),
+        options_(options) {}
 
  private:
   void HandleTranslationUnit(clang::ASTContext& context) override;
@@ -132,6 +140,7 @@ class GeneratorASTConsumer : public clang::ASTConsumer {
   std::string in_file_;
   GeneratorASTVisitor visitor_;
   EmitterBase& emitter_;
+  const GeneratorOptions& options_;
 };
 
 class GeneratorAction : public clang::ASTFrontendAction {


### PR DESCRIPTION
### Motivation
Fixes #94

In `sapi_library`, users specify a list of functions to sandbox (`functions`). Previously, when a requested symbol did not exist in the translation unit (e.g. Due to an upstream API signature change, typo, or missing export), it was silently ignored. The generator proceeded to emit an incomplete SAPI header without any failure or error indication during the build, leading to difficult debugging when functions were missing from the generated API class.

### Changes
1. **`sandboxed_api/tools/clang_generator/generator.h`**:
   - Added `found_functions_` set and accessor in `GeneratorASTVisitor` to track requested function names that were successfully visited.
   - Stored `const GeneratorOptions& options_` in `GeneratorASTConsumer`.
2. **`sandboxed_api/tools/clang_generator/generator.cc`**:
   - Recorded visited functions matching `options_.function_names`.
   - In `GeneratorASTConsumer::HandleTranslationUnit`, verified that each requested function in `options_.function_names` was found. If any requested function is missing, reports a `clang::DiagnosticsEngine::Error` diagnostic indicating the missing function name.
3. **`sandboxed_api/tools/clang_generator/emitter_test.cc`**:
   - Added regression test `NonExistentFunctionFails` confirming that requesting an undefined function fails tool invocation with an error.
